### PR TITLE
Fix the issue of "Tag <blah> incompatible with output codec id '<blah>'"

### DIFF
--- a/omxtx.c
+++ b/omxtx.c
@@ -371,7 +371,7 @@ printf("Time base: %d/%d, fps %d/%d\n", oflow->time_base.num, oflow->time_base.d
 			avcodec_copy_context(oflow->codec, iflow->codec);
 		/* Apparently fixes a crash on .mkvs with attachments: */
 			av_dict_copy(&oflow->metadata, iflow->metadata, 0);
-                        oflow->codec->codec_tag = 0; /* Reset the codec tag so as not to cause problems with output format */
+			oflow->codec->codec_tag = 0; /* Reset the codec tag so as not to cause problems with output format */
 		}
 	}
 	for (i = 0; i < oc->nb_streams; i++) {


### PR DESCRIPTION
This little fix solves the above problem where libavformat refuses to write the header while complaining about an obscure tag value.

It turns out that libavformat doesn't like the codec_tag that is copied into the output stream codec context from the input stream codec context. Setting this to 0 allows the correct codec_tag for the output container format to be selected when the header is written.
