### PR TITLE
Major update - Fixed H264 header info, PTS timing, option to remove subtitles...

### DIFF
--- a/omxtx.c
+++ b/omxtx.c
@@ -1,6 +1,8 @@
 /* omxtx.c
  *
  * (c) 2012 Dickon Hood <dickon@fluff.org>
+ * With addtions from:
+ * Adam Charrett <adam@dvbstreamer.org>
  *
  * A trivial OpenMAX transcoder for the Pi.
  *
@@ -28,11 +30,6 @@
 /* To do:
  *
  *  *  Flush the buffers at the end
- *  *  Sort out the PTSes
- *  *  Read up on buffer timings in general
- *  *  Feed the packets to AVFormat rather than dumping them raw to disc
- *  *  Interleave correctly with the other AV packets in the stream, rather
- *     than just dropping them entirely
  */
 
 #define _BSD_SOURCE
@@ -1619,8 +1616,8 @@ int main(int argc, char *argv[])
 
     end = time(NULL);
 
-    printf("Processed %d frames in %d seconds; %df/s\n\n\n",
-        ctx.framecount, end-start, (ctx.framecount/(end-start)));
+    printf("Processed %lld frames in %d seconds; %lldf/s\n\n\n",
+        ctx.framecount, end-start, (ctx.framecount/(int64_t)(end-start)));
 
     if (oc) {
         av_write_trailer(oc);

--- a/omxtx.c
+++ b/omxtx.c
@@ -43,24 +43,12 @@
 #include <stdlib.h>
 #include <stdbool.h>
 #include <string.h>
-#include "bcm_host.h"
-#include "libavformat/avformat.h"
-#include "libavutil/avutil.h"
-#include "libavcodec/avcodec.h"
-#include "libavutil/mathematics.h"
-#include "libavformat/avio.h"
-#include <error.h>
-
-#include "OMX_Video.h"
-#include "OMX_Types.h"
-#include "OMX_Component.h"
-#include "OMX_Core.h"
-#include "OMX_Broadcom.h"
 
 #include <pthread.h>
 
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <sys/queue.h>
 #include <fcntl.h>
 
 #include <time.h>
@@ -70,48 +58,82 @@
 
 /* For htonl(): */
 #include <arpa/inet.h>
+#include <error.h>
+
+#include "libavformat/avformat.h"
+#include "libavutil/avutil.h"
+#include "libavcodec/avcodec.h"
+#include "libavutil/mathematics.h"
+#include "libavformat/avio.h"
+
+#ifndef AVIO_FLAG_WRITE
+#define AVIO_FLAG_WRITE URL_WRONLY
+#endif
+
+
+#include "bcm_host.h"
+#include "OMX_Video.h"
+#include "OMX_Types.h"
+#include "OMX_Component.h"
+#include "OMX_Core.h"
+#include "OMX_Broadcom.h"
+
 
 static OMX_VERSIONTYPE SpecificationVersion = {
-	.s.nVersionMajor = 1,
-	.s.nVersionMinor = 1,
-	.s.nRevision     = 2,
-	.s.nStep         = 0
+    .s.nVersionMajor = 1,
+    .s.nVersionMinor = 1,
+    .s.nRevision     = 2,
+    .s.nStep         = 0
 };
 
 /* Hateful things: */
-#define MAKEME(y, x)	do {						\
-				y = calloc(1, sizeof(x));		\
-				y->nSize = sizeof(x);			\
-				y->nVersion = SpecificationVersion;	\
-			} while (0)
+#define MAKEME(y, x) do {      \
+                y = calloc(1, sizeof(x));  \
+                y->nSize = sizeof(x);   \
+                y->nVersion = SpecificationVersion; \
+            } while (0)
+
+#define SETUPME(x) do { \
+                (x).nSize = sizeof(x); \
+                (x).nVersion = SpecificationVersion; \
+            } while (0)
+
+#define OERR(cmd) do {      \
+                OMX_ERRORTYPE oerr = cmd;  \
+                if (oerr != OMX_ErrorNone) {  \
+                    fprintf(stderr, #cmd  \
+                        " failed on line %d: %x\n", \
+                        __LINE__, oerr); \
+                    exit(1);   \
+                } else {    \
+                    vprintf( V_LOTS, #cmd  \
+                        " completed at %d.\n", \
+                        __LINE__);  \
+                }     \
+            } while (0)
 
 
-#define OERR(cmd)	do {						\
-				OMX_ERRORTYPE oerr = cmd;		\
-				if (oerr != OMX_ErrorNone) {		\
-					fprintf(stderr, #cmd		\
-						" failed on line %d: %x\n", \
-						__LINE__, oerr);	\
-					exit(1);			\
-				}					\
-			} while(0)
-/*
-				} else {				\
-					fprintf(stderr, #cmd		\
-						" completed at %d.\n",	\
-						__LINE__);		\
-				}					\
-			} while (0)
-*/
-
-#define OERRq(cmd)	do {	oerr = cmd;				\
-				if (oerr != OMX_ErrorNone) {		\
-					fprintf(stderr, #cmd		\
-						" failed: %x\n", oerr);	\
-					exit(1);			\
-				}					\
-			} while (0)
+#define OERRq(cmd) do {\
+                OMX_ERRORTYPE oerr = cmd;    \
+                if (oerr != OMX_ErrorNone) {  \
+                    fprintf(stderr, #cmd  \
+                        " failed: %x\n", oerr); \
+      exit(1);   \
+                }     \
+            } while (0)
 /* ... but damn useful.*/
+
+#define V_ALWAYS 0
+#define V_INFO    1
+#define V_LOTS    2
+
+#define vprintf(v, ...) \
+    do { \
+        if ((v) <= ctx.verbosity) { \
+            printf( __VA_ARGS__); \
+        } \
+    } while (0)
+
 
 /* Hardware component names: */
 #define ENCNAME "OMX.broadcom.video_encode"
@@ -119,7 +141,7 @@ static OMX_VERSIONTYPE SpecificationVersion = {
 #define RSZNAME "OMX.broadcom.resize"
 #define VIDNAME "OMX.broadcom.video_render"
 #define SPLNAME "OMX.broadcom.video_splitter"
-#define DEINAME	"OMX.broadcom.image_fx"
+#define DEINAME "OMX.broadcom.image_fx"
 
 /* portbase for the modules, could also be queried, but as the components are broadcom/raspberry
    specific anyway... */
@@ -131,1596 +153,1495 @@ static OMX_VERSIONTYPE SpecificationVersion = {
 #define PORT_SPL 250
 
 enum states {
-	DECINIT,
-	DECTUNNELSETUP,
-	DECRUNNING,
-	DECFLUSH,
-	DECDONE,
-	DECFAILED,
-	ENCPREINIT,
-	ENCINIT,
-	ENCGOTBUF,
-	ENCDONE,
+    DECINIT,
+    DECTUNNELSETUP,
+    DECRUNNING,
+    ENCSPSPPS,
+    ENCRUNNING,
+    DECFLUSH,
+    DECDONE,
+    DECFAILED,
+    ENCPREINIT,
+    ENCINIT,
+    ENCGOTBUF,
+    ENCDONE,
 };
 
 
+struct event_info {
+    TAILQ_ENTRY(event_info) link;
+    char *name;
+    OMX_HANDLETYPE component;
+    OMX_EVENTTYPE event;
+    OMX_U32 data1;
+    OMX_U32 data2;
+    OMX_PTR eventdata;
+};
+
+
+struct event_queue{
+    pthread_mutex_t lock;
+    pthread_cond_t notify;
+    TAILQ_HEAD(event_queue_head, event_info) head;
+} eventq = {
+        .lock = PTHREAD_MUTEX_INITIALIZER,
+        .notify = PTHREAD_COND_INITIALIZER
+};
+
+struct packet_entry {
+    TAILQ_ENTRY(packet_entry) link;
+    AVPacket packet;
+};
+
+TAILQ_HEAD(packet_queue, packet_entry);
+
+static struct packet_queue packetq;
+
 
 static struct context {
-	AVFormatContext *ic;
-	AVFormatContext *oc;
-	int		nextin;
-	int		nextout;
-	int		incount;
-	int		outcount;
-	volatile int	fps;
-	volatile int	framecount;
-	int		done;
-	volatile int	flags;
-	OMX_BUFFERHEADERTYPE *encbufs, *bufhead;
-	volatile enum states	decstate;
-	volatile enum states	encstate;
-	int		vidindex;
-	OMX_HANDLETYPE	dec, enc, rsz, dei;
-	pthread_mutex_t	lock;
-	AVBitStreamFilterContext *bsfc;
-	int		bitrate;
-	char		*resize;
-	char		*oname;
-	double		frameduration;
-	bool		no_subtitles;
-	int 		*stream_out_idx;
-;
+    int verbosity;
+    AVFormatContext *ic;
+    AVFormatContext *oc;
+    int fd;
+    int  nextin;
+    int  nextout;
+    int  incount;
+    int  outcount;
+    volatile int64_t framecount;
+    int  done;
+    volatile int flags;
+    OMX_BUFFERHEADERTYPE *encbufs, *bufhead;
+    volatile enum states decstate;
+    volatile enum states encstate;
+    int  vidindex;
+    OMX_HANDLETYPE dec, enc, rsz, dei;
+    pthread_mutex_t lock;
+    AVBitStreamFilterContext *bsfc;
+    int  bitrate;
+    char  *resize;
+    char  *oname;
+    double  frameduration;
+    bool  no_subtitles;
+    int   *stream_out_idx;
 } ctx;
-#define FLAGS_VERBOSE		(1<<0)
-#define FLAGS_DECEMPTIEDBUF	(1<<1)
-#define FLAGS_MONITOR		(1<<2)
-#define FLAGS_DEINTERLACE	(1<<3)
-#define FLAGS_RAW		(1<<4)
 
-
-
-static OMX_BUFFERHEADERTYPE *allocbufs(OMX_HANDLETYPE h, int port, int enable);
-
+#define FLAGS_DECEMPTIEDBUF (1<<0)
+#define FLAGS_MONITOR       (1<<1)
+#define FLAGS_DEINTERLACE   (1<<2)
+#define FLAGS_RAW           (1<<3)
 
 /* Print some useful information about the state of the port: */
-static void dumpport(OMX_HANDLETYPE handle, int port)
+static void dumpPort(OMX_HANDLETYPE handle, int port)
 {
-	OMX_VIDEO_PORTDEFINITIONTYPE	*viddef;
-	OMX_PARAM_PORTDEFINITIONTYPE	*portdef;
-return;
-	MAKEME(portdef, OMX_PARAM_PORTDEFINITIONTYPE);
-	portdef->nPortIndex = port;
-	OERR(OMX_GetParameter(handle, OMX_IndexParamPortDefinition, portdef));
+    OMX_VIDEO_PORTDEFINITIONTYPE *viddef;
+    OMX_PARAM_PORTDEFINITIONTYPE *portdef;
 
-	printf("Port %d is %s, %s\n", portdef->nPortIndex,
-		(portdef->eDir == 0 ? "input" : "output"),
-		(portdef->bEnabled == 0 ? "disabled" : "enabled"));
-	printf("Wants %d bufs, needs %d, size %d, enabled: %d, pop: %d, "
-		"aligned %d\n", portdef->nBufferCountActual,
-		portdef->nBufferCountMin, portdef->nBufferSize,
-		portdef->bEnabled, portdef->bPopulated,
-		portdef->nBufferAlignment);
-	viddef = &portdef->format.video;
+    MAKEME(portdef, OMX_PARAM_PORTDEFINITIONTYPE);
+    portdef->nPortIndex = port;
+    OERR(OMX_GetParameter(handle, OMX_IndexParamPortDefinition, portdef));
 
-	switch (portdef->eDomain) {
-	case OMX_PortDomainVideo:
-		printf("Video type is currently:\n"
-			"\tMIME:\t\t%s\n"
-			"\tNative:\t\t%p\n"
-			"\tWidth:\t\t%d\n"
-			"\tHeight:\t\t%d\n"
-			"\tStride:\t\t%d\n"
-			"\tSliceHeight:\t%d\n"
-			"\tBitrate:\t%d\n"
-			"\tFramerate:\t%d (%x); (%f)\n"
-			"\tError hiding:\t%d\n"
-			"\tCodec:\t\t%d\n"
-			"\tColour:\t\t%d\n",
-			viddef->cMIMEType, viddef->pNativeRender,
-			viddef->nFrameWidth, viddef->nFrameHeight,
-			viddef->nStride, viddef->nSliceHeight,
-			viddef->nBitrate,
-			viddef->xFramerate, viddef->xFramerate,
-			((float)viddef->xFramerate/(float)65536),
-			viddef->bFlagErrorConcealment,
-			viddef->eCompressionFormat, viddef->eColorFormat);
-		break;
-	case OMX_PortDomainImage:
-		printf("Image type is currently:\n"
-			"\tMIME:\t\t%s\n"
-			"\tNative:\t\t%p\n"
-			"\tWidth:\t\t%d\n"
-			"\tHeight:\t\t%d\n"
-			"\tStride:\t\t%d\n"
-			"\tSliceHeight:\t%d\n"
-			"\tError hiding:\t%d\n"
-			"\tCodec:\t\t%d\n"
-			"\tColour:\t\t%d\n",
-			portdef->format.image.cMIMEType,
-			portdef->format.image.pNativeRender,
-			portdef->format.image.nFrameWidth,
-			portdef->format.image.nFrameHeight,
-			portdef->format.image.nStride,
-			portdef->format.image.nSliceHeight,
-			portdef->format.image.bFlagErrorConcealment,
-			portdef->format.image.eCompressionFormat,
-			portdef->format.image.eColorFormat); 		
-		break;
+    vprintf(V_LOTS, "Port %d is %s, %s\n", portdef->nPortIndex,
+        (portdef->eDir == 0 ? "input" : "output"),
+        (portdef->bEnabled == 0 ? "disabled" : "enabled"));
+    vprintf(V_LOTS, "Wants %d bufs, needs %d, size %d, enabled: %d, pop: %d, "
+        "aligned %d\n", portdef->nBufferCountActual,
+        portdef->nBufferCountMin, portdef->nBufferSize,
+        portdef->bEnabled, portdef->bPopulated,
+        portdef->nBufferAlignment);
+    viddef = &portdef->format.video;
+
+    switch (portdef->eDomain) {
+    case OMX_PortDomainVideo:
+        vprintf(V_LOTS, "Video type is currently:\n"
+            "\tMIME:\t\t%s\n"
+            "\tNative:\t\t%p\n"
+            "\tWidth:\t\t%d\n"
+            "\tHeight:\t\t%d\n"
+            "\tStride:\t\t%d\n"
+            "\tSliceHeight:\t%d\n"
+            "\tBitrate:\t%d\n"
+            "\tFramerate:\t%d (%x); (%f)\n"
+            "\tError hiding:\t%d\n"
+            "\tCodec:\t\t%d\n"
+            "\tColour:\t\t%d\n",
+            viddef->cMIMEType, viddef->pNativeRender,
+            viddef->nFrameWidth, viddef->nFrameHeight,
+            viddef->nStride, viddef->nSliceHeight,
+            viddef->nBitrate,
+            viddef->xFramerate, viddef->xFramerate,
+            ((float)viddef->xFramerate/(float)65536),
+            viddef->bFlagErrorConcealment,
+            viddef->eCompressionFormat, viddef->eColorFormat);
+        break;
+    case OMX_PortDomainImage:
+        vprintf(V_LOTS, "Image type is currently:\n"
+            "\tMIME:\t\t%s\n"
+            "\tNative:\t\t%p\n"
+            "\tWidth:\t\t%d\n"
+            "\tHeight:\t\t%d\n"
+            "\tStride:\t\t%d\n"
+            "\tSliceHeight:\t%d\n"
+            "\tError hiding:\t%d\n"
+            "\tCodec:\t\t%d\n"
+            "\tColour:\t\t%d\n",
+            portdef->format.image.cMIMEType,
+            portdef->format.image.pNativeRender,
+            portdef->format.image.nFrameWidth,
+            portdef->format.image.nFrameHeight,
+            portdef->format.image.nStride,
+            portdef->format.image.nSliceHeight,
+            portdef->format.image.bFlagErrorConcealment,
+            portdef->format.image.eCompressionFormat,
+            portdef->format.image.eColorFormat);   
+        break;
 /* Feel free to add others. */
-	default:
-		break;
-	}
+    default:
+        break;
+    }
 
-	free(portdef);
+    free(portdef);
 }
 
 
-static int mapcodec(enum CodecID id)
+static void dumpPortState(void)
 {
-	printf("Mapping codec ID %d (%x)\n", id, id);
-	switch (id) {
-		case	CODEC_ID_MPEG2VIDEO:
-		case	CODEC_ID_MPEG2VIDEO_XVMC:
-			return OMX_VIDEO_CodingMPEG2;
-		case	CODEC_ID_H264:
-			return OMX_VIDEO_CodingAVC;
-		case	13:
-			return OMX_VIDEO_CodingMPEG4;
-		default:
-			return -1;
-	}
+    enum OMX_STATETYPE  state;
 
-	return -1;
+    vprintf(V_LOTS, "\n\nIn exit handler, after %d frames:\n", ctx.framecount);
+    dumpPort(ctx.dec, PORT_DEC);
+    dumpPort(ctx.dec, PORT_DEC+1);
+    dumpPort(ctx.enc, PORT_ENC);
+    dumpPort(ctx.enc, PORT_ENC+1);
+
+    OMX_GetState(ctx.dec, &state);
+    vprintf(V_LOTS, "Decoder state: %d\n", state);
+    OMX_GetState(ctx.enc, &state);
+    vprintf(V_LOTS, "Encoder state: %d\n", state);
 }
 
 
-static void dumpportstate(void)
+static int mapCodec(enum CodecID id)
 {
-	enum OMX_STATETYPE		state;
-
-	printf("\n\nIn exit handler, after %d frames:\n", ctx.framecount);
-	dumpport(ctx.dec, PORT_DEC);
-	dumpport(ctx.dec, PORT_DEC+1);
-	dumpport(ctx.enc, PORT_ENC);
-	dumpport(ctx.enc, PORT_ENC+1);
-
-	OMX_GetState(ctx.dec, &state);
-	printf("Decoder state: %d\n", state);
-	OMX_GetState(ctx.enc, &state);
-	printf("Encoder state: %d\n", state);
+    switch (id) {
+        case CODEC_ID_MPEG2VIDEO:
+        case CODEC_ID_MPEG2VIDEO_XVMC:
+            return OMX_VIDEO_CodingMPEG2;
+        case CODEC_ID_H264:
+            return OMX_VIDEO_CodingAVC;
+        case CODEC_ID_MPEG4:
+            return OMX_VIDEO_CodingMPEG4;
+        default:
+            return -1;
+    }
+    return -1;
 }
 
-
-
-static const char *mapcomponent(struct context *ctx, OMX_HANDLETYPE h)
+static AVFormatContext *makeOutputContext(AVFormatContext *ic,
+    const char *oname, int idx, const OMX_PARAM_PORTDEFINITIONTYPE *prt)
 {
-	if (h == ctx->dec)
-		return "Decoder";
-	if (h == ctx->enc)
-		return "Encoder";
-	if (h == ctx->rsz)
-		return "Resizer";
-	return "Unknown!";
+    AVFormatContext   *oc;
+    AVOutputFormat   *fmt;
+    int    i;
+    AVStream   *iflow, *oflow;
+    AVCodec    *c;
+    AVCodecContext   *cc;
+    const OMX_VIDEO_PORTDEFINITIONTYPE *viddef;
+    int     stream_idx;
+
+    viddef = &prt->format.video;
+
+    fmt = av_guess_format(NULL, oname, NULL);
+    if (!fmt) {
+        fprintf(stderr, "Can't guess format for %s; defaulting to "
+            "MPEG\n",
+            oname);
+        fmt = av_guess_format(NULL, "MPEG", NULL);
+    }
+    if (!fmt) {
+        fprintf(stderr, "Failed even that.  Bye bye.\n");
+        exit(1);
+    }
+
+    oc = avformat_alloc_context();
+    if (!oc) {
+        fprintf(stderr, "Failed to alloc outputcontext\n");
+        exit(1);
+    }
+    oc->oformat = fmt;
+    snprintf(oc->filename, sizeof(oc->filename), "%s", oname);
+    oc->debug = 1;
+    oc->start_time_realtime = ic->start_time;
+    oc->start_time = ic->start_time;
+
+    oc->duration = 0;
+    ctx.stream_out_idx = calloc(ic->nb_streams, sizeof(int));
+    stream_idx = 0;
+    oc->bit_rate = 0;
+    for (i = 0; i < ic->nb_streams; i++) {
+        iflow = ic->streams[i];
+        if (i == idx) { /* My new H.264 stream. */
+            ctx.stream_out_idx[i] = stream_idx;
+            stream_idx ++;
+            c = avcodec_find_encoder(CODEC_ID_H264);
+            oflow = avformat_new_stream(oc, c);
+            cc = oflow->codec;
+            cc->width = viddef->nFrameWidth;
+            cc->height = viddef->nFrameHeight;
+            cc->time_base = iflow->codec->time_base;
+            cc->codec_id = CODEC_ID_H264;
+            cc->codec_type = AVMEDIA_TYPE_VIDEO;
+            cc->bit_rate = ctx.bitrate;
+
+            oflow->avg_frame_rate = iflow->avg_frame_rate;
+            oflow->r_frame_rate = iflow->r_frame_rate;
+            oflow->start_time = iflow->start_time;
+            printf("Start Time (oc) %lld (oflow) %lld\n", oc->start_time, oflow->start_time);
+
+            if (!ctx.resize)  {
+                cc->sample_aspect_ratio.num = iflow->codec->sample_aspect_ratio.num;
+                cc->sample_aspect_ratio.den = iflow->codec->sample_aspect_ratio.den;
+                oflow->sample_aspect_ratio.num = iflow->codec->sample_aspect_ratio.num;
+                oflow->sample_aspect_ratio.den = iflow->codec->sample_aspect_ratio.den;
+            }
+        } else {  /* Something pre-existing. */
+            bool add_stream = true;
+
+            if (ctx.no_subtitles && 
+                ((iflow->codec->codec_id >= CODEC_ID_FIRST_SUBTITLE) && (iflow->codec->codec_id < CODEC_ID_FIRST_UNKNOWN)))
+            {
+                add_stream = false;
+            }
+
+            if (add_stream)
+            {
+                c = avcodec_find_encoder(iflow->codec->codec_id);
+                oflow = avformat_new_stream(oc, c);
+                avcodec_copy_context(oflow->codec, iflow->codec);
+                /* Apparently fixes a crash on .mkvs with attachments: */
+                av_dict_copy(&oflow->metadata, iflow->metadata, 0);
+                oflow->codec->codec_tag = 0; /* Reset the codec tag so as not to cause problems with output format */
+                ctx.stream_out_idx[i] = stream_idx;
+                stream_idx ++;
+            }
+            else
+            {
+                ctx.stream_out_idx[i] = -1;
+            }
+        }
+    }
+
+    for (i = 0; i < oc->nb_streams; i++) {
+        if (oc->oformat->flags & AVFMT_GLOBALHEADER) {
+            oc->streams[i]->codec->flags |= CODEC_FLAG_GLOBAL_HEADER;
+        }
+        
+        if (oc->streams[i]->codec->sample_rate == 0) {
+            oc->streams[i]->codec->sample_rate = 48000; /* ish */
+        }
+    }
+    av_dump_format(oc, 0, oname, 1);
+    return oc;
 }
 
 
-
-static AVFormatContext *makeoutputcontext(AVFormatContext *ic,
-	const char *oname, int idx, const OMX_PARAM_PORTDEFINITIONTYPE *prt,
-	AVPacket **ifb)
+static void writeNonVideoPacket(AVPacket *pkt)
 {
-	AVFormatContext			*oc;
-	AVOutputFormat			*fmt;
-	int				i;
-	AVStream			*iflow, *oflow;
-	AVCodec				*c;
-	AVCodecContext			*cc;
-	const OMX_VIDEO_PORTDEFINITIONTYPE	*viddef;
-	int				r;
-	char				err[256];
-	int 				stream_idx;
+    int index = pkt->stream_index;
+    int outIndex = ctx.stream_out_idx[index];
 
-	viddef = &prt->format.video;
-
-	fmt = av_guess_format(NULL, oname, NULL);
-	if (!fmt) {
-		fprintf(stderr, "Can't guess format for %s; defaulting to "
-			"MPEG\n",
-			oname);
-		fmt = av_guess_format(NULL, "MPEG", NULL);
-	}
-	if (!fmt) {
-		fprintf(stderr, "Failed even that.  Bye bye.\n");
-		exit(1);
-	}
-
-	oc = avformat_alloc_context();
-	if (!oc) {
-		fprintf(stderr, "Failed to alloc outputcontext\n");
-		exit(1);
-	}
-	oc->oformat = fmt;
-	snprintf(oc->filename, sizeof(oc->filename), "%s", oname);
-	oc->debug = 1;
-	oc->start_time_realtime = ic->start_time_realtime;
-	oc->start_time = ic->start_time;
-printf("# input stream: %d\n", ic->nb_streams);
-	ctx.stream_out_idx = calloc(ic->nb_streams, sizeof(int));
-	stream_idx = 0;
-#define ETB(x) x.num, x.den
-	for (i = 0; i < ic->nb_streams; i++) {
-		iflow = ic->streams[i];
-		if (i == idx) {	/* My new H.264 stream. */
-printf("Video stream %d\n", stream_idx);
-                        ctx.stream_out_idx[i] = stream_idx;
-			stream_idx ++;
-			c = avcodec_find_encoder(CODEC_ID_H264);
-printf("Found a codec at %p\n", c);
-			oflow = avformat_new_stream(oc, c);
-printf("Defaults: output stream: %d/%d, input stream: %d/%d, input codec: %d/%d, output codec: %d/%d, output framerate: %d/%d, input framerate: %d/%d, ticks: %d; %d %lld/%lld\n", ETB(oflow->time_base), ETB(iflow->time_base), ETB(iflow->codec->time_base), ETB(oflow->codec->time_base), ETB(oflow->r_frame_rate), ETB(iflow->r_frame_rate), oflow->codec->ticks_per_frame, iflow->codec->ticks_per_frame, oc->start_time_realtime, ic->start_time_realtime);
-			cc = oflow->codec;
-			cc->width = viddef->nFrameWidth;
-			cc->height = viddef->nFrameHeight;
-			cc->time_base = iflow->codec->time_base;
-			cc->codec_id = CODEC_ID_H264;
-			cc->codec_type = AVMEDIA_TYPE_VIDEO;
-			cc->max_b_frames = 12;	/* Probably wrong */
-			cc->has_b_frames = 1;
-			cc->gop_size = 200;
-			cc->pix_fmt = PIX_FMT_YUV420P;
-			cc->bit_rate = ctx.bitrate;
-			cc->profile = FF_PROFILE_H264_HIGH;
-			cc->level = 41;
-			oflow->avg_frame_rate = iflow->avg_frame_rate;
-			oflow->r_frame_rate = iflow->r_frame_rate;
-			oflow->time_base = iflow->time_base;
-			cc->flags = CODEC_FLAG2_LOCAL_HEADER;
-			oflow->start_time = iflow->start_time;
-printf("Defaults: output stream: %d/%d, input stream: %d/%d, input codec: %d/%d, output codec: %d/%d, output framerate: %d/%d, input framerate: %d/%d\n", ETB(oflow->time_base), ETB(iflow->time_base), ETB(iflow->codec->time_base), ETB(oflow->codec->time_base), ETB(oflow->r_frame_rate), ETB(iflow->r_frame_rate));
-printf("Time base: %d/%d, fps %d/%d\n", oflow->time_base.num, oflow->time_base.den, oflow->r_frame_rate.num, oflow->r_frame_rate.den);
-//			oflow->sample_aspect_ratio = iflow->sample_aspect_ratio;
-		} else { 	/* Something pre-existing. */
-			bool add_stream = true;
-
-			if (ctx.no_subtitles && 
-				((iflow->codec->codec_id >= CODEC_ID_FIRST_SUBTITLE) && (iflow->codec->codec_id < CODEC_ID_FIRST_UNKNOWN)))
-			{
-				add_stream = false;
-			}
-
-			if (add_stream)
-			{
-printf("Other stream %d\n", stream_idx);
-				c = avcodec_find_encoder(iflow->codec->codec_id);
-				oflow = avformat_new_stream(oc, c);
-				avcodec_copy_context(oflow->codec, iflow->codec);
-				/* Apparently fixes a crash on .mkvs with attachments: */
-				av_dict_copy(&oflow->metadata, iflow->metadata, 0);
-				oflow->codec->codec_tag = 0; /* Reset the codec tag so as not to cause problems with output format */
-				ctx.stream_out_idx[i] = stream_idx;
-				stream_idx ++;
-			}
-			else
-			{
-				ctx.stream_out_idx[i] = -1;
-			}
-
-		}
-	}
-	for (i = 0; i < oc->nb_streams; i++) {
-		if (oc->oformat->flags & AVFMT_GLOBALHEADER)
-			oc->streams[i]->codec->flags
-				|= CODEC_FLAG_GLOBAL_HEADER;
-		if (oc->streams[i]->codec->sample_rate == 0)
-			oc->streams[i]->codec->sample_rate = 48000; /* ish */
-	}
-
-printf("\n\n\nInput:\n");
-	av_dump_format(ic, 0, ic->filename, 0);
-printf("\n\n\nOutput:\n");
-	av_dump_format(oc, 0, oname, 1);
-
-/* At some point they changed the API: */
-#ifndef URL_WRONLY
-#define URL_WRONLY AVIO_FLAG_WRITE
-#endif
-	avio_open(&oc->pb, oname, URL_WRONLY);
-
-	r = avformat_write_header(oc, NULL);
-	if (r < 0) {
-		av_strerror(r, err, sizeof(err));
-		printf("Failed to write header: %s\n", err);
-		exit(1);
-	}
-
-	printf("Writing initial frame buffer contents out...");
-	for (i = 0; ifb[i]; i++) {
-		AVPacket *rp;
-		int index;
-		rp = ifb[i];
-		index = rp->stream_index;
-
-		if (rp->pts != AV_NOPTS_VALUE)
-			rp->pts = av_rescale_q(rp->pts,
-				ic->streams[index]->time_base,
-				oc->streams[index]->time_base);
-		if (rp->dts != AV_NOPTS_VALUE)
-			rp->dts = av_rescale_q(rp->dts,
-				ic->streams[index]->time_base,
-				oc->streams[index]->time_base);
-		av_interleaved_write_frame(oc, rp);
-	}
-
-	printf(" ...done.  Wrote %d frames.\n\n", i);
-
-	return oc;
+    if (outIndex != -1) {
+        pkt->stream_index = outIndex;
+        if (pkt->pts != AV_NOPTS_VALUE) {
+            pkt->pts = av_rescale_q(pkt->pts, ctx.ic->streams[index]->time_base, ctx.oc->streams[outIndex]->time_base);
+            pkt->pts -= ctx.oc->start_time / 1000;
+        }
+        
+        if (pkt->dts != AV_NOPTS_VALUE) {
+            pkt->dts = av_rescale_q(pkt->dts, ctx.ic->streams[index]->time_base, ctx.oc->streams[outIndex]->time_base);
+            pkt->dts  -= ctx.oc->start_time / 1000;
+        }
+        vprintf(V_LOTS, "Other PTS %lld\n", pkt->pts);
+        av_interleaved_write_frame(ctx.oc, pkt);
+    } else {
+        av_free_packet(pkt);
+    }
 }
 
+static void openOutputFile(void)
+{
+    int i;
+    int r;
+    struct packet_entry *packet;
+    struct packet_entry *next_packet;
+    AVFormatContext *oc = ctx.oc;
+    
+    vprintf(V_LOTS, "Opening output file\n");
+    avio_open(&oc->pb, ctx.oname, AVIO_FLAG_WRITE);
+    r = avformat_write_header(oc, NULL);
+    if (r < 0) {
+        char errstr[256];
+        av_strerror(r, errstr, sizeof(errstr));
+        fprintf(stderr, "Failed to write header: %s\n", errstr);
+        exit(1);
+    }
 
+    vprintf(V_LOTS, "Writing initial frame buffer contents out...");
+    
+    for (i = 0, packet = TAILQ_FIRST(&packetq); packet != NULL; packet = next_packet) {
+        next_packet = TAILQ_NEXT(packet, link);
+        
+        if (packet->packet.stream_index != ctx.vidindex) {
+            i ++;
+            writeNonVideoPacket(&packet->packet);
+        } else {
+            av_free_packet(&packet->packet);
+        }
+        TAILQ_REMOVE(&packetq, packet, link);
+        free(packet);
+    }
+
+    vprintf(V_LOTS, " ...done.  Wrote %d frames.\n\n", i);
+}
 
 OMX_ERRORTYPE genericeventhandler(OMX_HANDLETYPE component,
-				struct context *ctx,
-				OMX_EVENTTYPE event,
-				OMX_U32 data1,
-				OMX_U32 data2,
-				OMX_PTR eventdata)
+                char *name,
+                OMX_EVENTTYPE event,
+                OMX_U32 data1,
+                OMX_U32 data2,
+                OMX_PTR eventdata)
 {
-	switch (event) {
-	case OMX_EventError:
-	if (ctx->flags & FLAGS_VERBOSE)
-		printf("%s %p has errored: %x\n", mapcomponent(ctx, component),
-			component, data1);
-		return data1;
-		break;
-	case OMX_EventCmdComplete:
-	if (ctx->flags & FLAGS_VERBOSE)
-		printf("%s %p has completed the last command.\n",
-			mapcomponent(ctx, component), component);
-		break;
-	case OMX_EventPortSettingsChanged: {
-//	if (ctx->flags & FLAGS_VERBOSE)
-		printf("%s %p port %d settings changed.\n",
-			mapcomponent(ctx, component), component, data1);
-		dumpport(component, data1);
-	}
-		break;
-	default:
-		if (ctx->flags & FLAGS_VERBOSE)
-			printf("Got an event of type %x on %s %p "
-				"(d1: %x, d2 %x)\n", event,
-				mapcomponent(ctx, component), component,
-				data1, data2);
-	}
-	
-	return OMX_ErrorNone;
+    struct event_info *msg;
+    vprintf(V_LOTS, "Event for %s type %x (data1 %x, data2 %x, eventdata %p)\n", 
+            name, event, data1, data2, eventdata);
+    
+    msg = calloc(1, sizeof(struct event_info));
+    msg->component = component;
+    msg->name = name;
+    msg->event = event;
+    msg->data1 = data1;
+    msg->data2 = data2;
+    msg->eventdata = eventdata;
+    vprintf(V_LOTS, "EventQ: Adding EventInfo %p\n", msg);
+    pthread_mutex_lock(&eventq.lock);
+    TAILQ_INSERT_TAIL(&eventq.head, msg, link);
+    pthread_cond_signal(&eventq.notify);
+    pthread_mutex_unlock(&eventq.lock);
+    
+    
+    if (event == OMX_EventError)
+        return data1;
+
+    return OMX_ErrorNone;
 }
 
 
 OMX_ERRORTYPE deceventhandler(OMX_HANDLETYPE component,
-				struct context *ctx,
-				OMX_EVENTTYPE event, 
-				OMX_U32 data1,
-				OMX_U32 data2,
-				OMX_PTR eventdata)
+                char *name,
+                OMX_EVENTTYPE event, 
+                OMX_U32 data1,
+                OMX_U32 data2,
+                OMX_PTR eventdata)
 {
-	if (event == OMX_EventPortSettingsChanged) {
-		ctx->decstate = DECTUNNELSETUP;
-	}
-	return genericeventhandler(component, ctx, event, data1, data2,
-		eventdata);
+    if (event == OMX_EventPortSettingsChanged) {
+        ctx.decstate = DECTUNNELSETUP;
+    }
+    return genericeventhandler(component, name, event, data1, data2, eventdata);
 }
-
-
-
-OMX_ERRORTYPE enceventhandler(OMX_HANDLETYPE component,
-				struct context *ctx,
-				OMX_EVENTTYPE event, 
-				OMX_U32 data1,
-				OMX_U32 data2,
-				OMX_PTR eventdata)
-{
-	return genericeventhandler(component, ctx, event, data1, data2,
-		eventdata);
-}
-
-
-
-OMX_ERRORTYPE rszeventhandler(OMX_HANDLETYPE component,
-				struct context *ctx,
-				OMX_EVENTTYPE event,
-				OMX_U32 data1,
-				OMX_U32 data2,
-				OMX_PTR eventdata)
-{
-	return genericeventhandler(component, ctx, event, data1, data2,
-		eventdata);
-}
-
 
 
 OMX_ERRORTYPE emptied(OMX_HANDLETYPE component,
-				struct context *ctx,
-				OMX_BUFFERHEADERTYPE *buf)
+                char *name,
+                OMX_BUFFERHEADERTYPE *buf)
 {
-	if (ctx->flags & FLAGS_VERBOSE)
-		printf("Got a buffer emptied event on %s %p, buf %p\n",
-			mapcomponent(ctx, component), component, buf);
-	buf->nFilledLen = 0;
-	ctx->flags |= FLAGS_DECEMPTIEDBUF;
-	return OMX_ErrorNone;
+    vprintf( V_LOTS, "Got a buffer emptied event on %s %p, buf %p\n", name, component, buf);
+    buf->nFilledLen = 0;
+    ctx.flags |= FLAGS_DECEMPTIEDBUF;
+    return OMX_ErrorNone;
 }
 
-
-
 OMX_ERRORTYPE filled(OMX_HANDLETYPE component,
-				struct context *ctx,
-				OMX_BUFFERHEADERTYPE *buf)
+                char *name,
+                OMX_BUFFERHEADERTYPE *buf)
 {
-	OMX_BUFFERHEADERTYPE *spare;
+    OMX_BUFFERHEADERTYPE *spare;
 
-	if (ctx->flags & FLAGS_VERBOSE)
-		printf("Got buffer %p filled (len %d)\n", buf,
-			buf->nFilledLen);
+    vprintf(V_LOTS, "Got buffer %p filled (len %d)\n", buf, buf->nFilledLen);
 
-/*
- * Don't call OMX_FillThisBuffer() here, as the hardware craps out after
- * a short while.  I don't know why.  Reentrancy, or the like, I suspect.
- * Queue the packet(s) and deal with them in main().
- *
- * It only ever seems to ask for the one buffer, but better safe than sorry...
- */
+    /*
+     * Don't call OMX_FillThisBuffer() here, as the hardware craps out after
+     * a short while.  I don't know why.  Reentrancy, or the like, I suspect.
+     * Queue the packet(s) and deal with them in main().
+     *
+     * It only ever seems to ask for the one buffer, but better safe than sorry...
+     */
 
-	pthread_mutex_lock(&ctx->lock);
-	if (ctx->bufhead == NULL) {
-		buf->pAppPrivate = NULL;
-		ctx->bufhead = buf;
-		pthread_mutex_unlock(&ctx->lock);
-		return OMX_ErrorNone;
-	}
+    pthread_mutex_lock(&ctx.lock);
+    if (ctx.bufhead == NULL) {
+        buf->pAppPrivate = NULL;
+        ctx.bufhead = buf;
+    } else {
+        spare = ctx.bufhead;
+        while (spare->pAppPrivate != NULL)
+            spare = spare->pAppPrivate;
 
-	spare = ctx->bufhead;
-	while (spare->pAppPrivate != NULL)
-		spare = spare->pAppPrivate;
+        spare->pAppPrivate = buf;
+        buf->pAppPrivate = NULL;
+    }
+    pthread_mutex_unlock(&ctx.lock);
 
-	spare->pAppPrivate = buf;
-	buf->pAppPrivate = NULL;
-	pthread_mutex_unlock(&ctx->lock);
-
-	return OMX_ErrorNone;
+    return OMX_ErrorNone;
 }
 
 
 OMX_CALLBACKTYPE encevents = {
-	(void (*)) enceventhandler,
-	(void (*)) emptied,
-	(void (*)) filled
+    (void (*)) genericeventhandler,
+    (void (*)) emptied,
+    (void (*)) filled
 };
 
 OMX_CALLBACKTYPE decevents = {
-	(void (*)) deceventhandler,
-	(void (*)) emptied,
-	(void (*)) filled
+    (void (*)) genericeventhandler,
+    (void (*)) emptied,
+    (void (*)) filled
 };
 
 OMX_CALLBACKTYPE rszevents = {
-	(void (*)) rszeventhandler,
-	(void (*)) emptied,
-	(void (*)) filled
+    (void (*)) genericeventhandler,
+    (void (*)) emptied,
+    (void (*)) filled
 };
 
 OMX_CALLBACKTYPE genevents = {
-	(void (*)) genericeventhandler,
-	(void (*)) emptied,
-	(void (*)) filled
+    (void (*)) genericeventhandler,
+    (void (*)) emptied,
+    (void (*)) filled
 };
 
+static bool getEvent(struct event_info *event, bool wait)
+{
+    struct event_info *qevent;
+    bool found = false;
+    pthread_mutex_lock(&eventq.lock);
+    do {
+        qevent = TAILQ_FIRST(&eventq.head);
+        if (qevent != NULL) {
+            vprintf(V_LOTS, "getEvent: EventInfo %p: %s Component %#x Event %#x data1 %#x data2 %#x eventdata %#x\n", qevent,
+                qevent->name, qevent->component, qevent->event, qevent->data1, qevent->data2, qevent->eventdata);
+            *event = *qevent;
+            found = true;
+            TAILQ_REMOVE(&eventq.head, qevent, link);
+            free(qevent);
+        }        
+        if (!found && wait){
+            vprintf(V_LOTS, "Waiting for event\n");
+            pthread_cond_wait(&eventq.notify, &eventq.lock);
+        }
+    } while(!found && wait);
+    pthread_mutex_unlock(&eventq.lock);
+    return found;
+}
 
+static int waitForCommand(OMX_HANDLETYPE h, OMX_COMMANDTYPE cmd, OMX_U32 data, OMX_PTR eventdata)
+{
+    int result = 0;
+    struct event_info *event;
+    bool found = false;
+    pthread_mutex_lock(&eventq.lock);
+    do {
+        TAILQ_FOREACH(event, &eventq.head, link){
+            vprintf(V_LOTS, "waitForCommand: EventInfo %p: %s Component %#x Event %#x data1 %#x data2 %#x eventdata %#x\n", event,
+                event->name, event->component, event->event, event->data1, event->data2, event->eventdata);
+            if (event->component == h){
+                if ((event->event == OMX_EventCmdComplete) &&
+                    (event->data1 == cmd) && 
+                    (event->data2 == data) && 
+                    (event->eventdata == eventdata))
+                {
+                    found = true;
+                }
+                if ((event->event == OMX_EventError) && 
+                     (event->data2 == 1))
+                {
+                    result = event->data1;
+                    found = true;
+                }
+                
+                if (found){
+                    TAILQ_REMOVE(&eventq.head, event, link);
+                    free(event);
+                    break;
+                }
+            }
+        }
+        if (!found){
+            vprintf(V_LOTS, "Waiting for event\n");
+            pthread_cond_wait(&eventq.notify, &eventq.lock);
+        }
+    } while(!found);
+    pthread_mutex_unlock(&eventq.lock);
+    
+    return result;
+}
+
+#define enablePort(h, p) _enablePort(h, p, __LINE__)
+static void _enablePort(OMX_HANDLETYPE h, int port, int line)
+{
+    int err;
+    vprintf(V_LOTS, "%d: Enabling port %d on component %#x\n", line, port, h);
+    OERRq(OMX_SendCommand(h, OMX_CommandPortEnable, port, NULL));
+    err = waitForCommand(h, OMX_CommandPortEnable, port, NULL);
+    if (err != 0) {
+        vprintf(V_ALWAYS, "Enable Port for Component %d port %d failed with error %#x\n", h, port, err);
+    }
+}
+
+#define enablePortNW(h, p) _enablePortNW(h, p, __LINE__)
+static void _enablePortNW(OMX_HANDLETYPE h, int port, int line)
+{
+    vprintf(V_LOTS, "%d: Enabling port %d on component %#x (Not waiting)\n", line, port, h);
+    OERRq(OMX_SendCommand(h, OMX_CommandPortEnable, port, NULL));
+}
+
+#define waitForPortEnabled(h, p) _waitForPortEnabled(h, p, __LINE__)
+static void _waitForPortEnabled(OMX_HANDLETYPE h, int port, int line)
+{
+    int err;
+    vprintf(V_LOTS, "%d: Waiting for port %d on component %#x to be enabled\n", line, port, h);
+    err = waitForCommand(h, OMX_CommandPortEnable, port, NULL);
+    if (err != 0) {
+        vprintf(V_ALWAYS, "Enable Port for Component %d port %d failed with error %#x\n", h, port, err);
+    }
+}
+
+#define disablePort(h, p) _disablePort(h, p, __LINE__)
+static void _disablePort(OMX_HANDLETYPE h, int port, int line)
+{
+    int err;
+    vprintf(V_LOTS, "%d: Disabling port %d on component %#x\n", line, port, h);
+    OERRq(OMX_SendCommand(h, OMX_CommandPortDisable, port, NULL));
+    err = waitForCommand(h, OMX_CommandPortDisable, port, NULL);
+    if (err != 0) {
+        vprintf(V_ALWAYS, "Disable Port for Component %d port %d failed with error %#x\n", h, port, err);
+    }
+}
+
+#define setState(h, s) _setState(h, s, __LINE__)
+static void _setState(OMX_HANDLETYPE h, int state, int line)
+{
+    int err;
+    vprintf(V_LOTS, "%d: Setting state %d on component %#x\n", line, state, h);
+    OERRq(OMX_SendCommand(h, OMX_CommandStateSet, state, NULL));
+    err = waitForCommand(h, OMX_CommandStateSet, state, NULL);
+
+    if (err != 0) {
+        vprintf(V_ALWAYS, "Set state for Component %d state %d failed with error %#x (line %d)\n", h, state, err, line);
+    }
+}
+
+#define transistionComponents(h, hc, s) _transistionComponents(h, hc, s, __LINE__)
+static void _transistionComponents(OMX_HANDLETYPE *handles, int hcount, int state, int line)
+{
+    int i;
+    
+    for (i = 0; i < hcount; i ++)
+    {
+        OERRq(OMX_SendCommand(handles[i], OMX_CommandStateSet, state, NULL));    
+    }
+    for (i = 0; i < hcount; i ++)
+    {
+        int err = waitForCommand(handles[i], OMX_CommandStateSet, state, NULL);    
+        if (err != 0) {
+            vprintf(V_ALWAYS, "Transitioning state for Component %d state %d failed with error %#x (line %d)\n", handles[i], state, err, line);
+        }
+    }
+}
+
+static void getPortDef(OMX_HANDLETYPE h, int port, OMX_PARAM_PORTDEFINITIONTYPE *portdef)
+{
+    portdef->nPortIndex = port;
+    OERR(OMX_GetParameter(h, OMX_IndexParamPortDefinition, portdef));
+}
+
+#define setPortDef(h, p, pd) _setPortDef(h,p,pd, __LINE__)
+static void _setPortDef(OMX_HANDLETYPE h, int port, OMX_PARAM_PORTDEFINITIONTYPE *portdef, int line)
+{
+    vprintf(V_LOTS, "%d: Setting port definition %p on port %d of componenent %#x\n", line, portdef, port, h);
+    portdef->nPortIndex = port;
+    OERR(OMX_SetParameter(h, OMX_IndexParamPortDefinition, portdef));
+}
 
 static void *fps(void *p)
 {
-	enum OMX_STATETYPE		state;
-	int				lastframe;
-
-	while (1) {
-		lastframe = ctx.framecount;
-		sleep(1);
-		printf("Frame %6d (%5ds).  Frames last second: %d     \r",
-			ctx.framecount, ctx.framecount/25,
-				ctx.framecount-lastframe);
-		fflush(stdout);
-		if (0 && ctx.fps == 0) {
-			printf("In fps thread, after %d frames:\n",
-				ctx.framecount);
-			dumpport(ctx.dec, PORT_DEC);
-			dumpport(ctx.dec, PORT_DEC+1);
-			dumpport(ctx.enc, PORT_ENC);
-			dumpport(ctx.enc, PORT_ENC+1);
-
-			OMX_GetState(ctx.dec, &state);
-			printf("Decoder state: %d\n", state);
-			OMX_GetState(ctx.enc, &state);
-			printf("Encoder state: %d\n", state);
-		}
-	}
-	return NULL;
+    int    lastframe;
+    while (1) {
+        lastframe = ctx.framecount;
+        sleep(1);
+        printf("Frame %6lld (%5llds).  Frames last second: %lld     \r",
+            ctx.framecount, ctx.framecount/25, 
+            ctx.framecount-lastframe);
+        fflush(stdout);
+    }
+    return NULL;
 }
 
 
 
-static OMX_BUFFERHEADERTYPE *allocbufs(OMX_HANDLETYPE h, int port, int enable)
+static OMX_BUFFERHEADERTYPE *allocBuffers(OMX_HANDLETYPE h, int port, int enable)
 {
-	int i;
-	OMX_BUFFERHEADERTYPE *list = NULL, **end = &list;
-	OMX_PARAM_PORTDEFINITIONTYPE *portdef;
+    int i;
+    OMX_BUFFERHEADERTYPE *list = NULL, **end = &list;
+    OMX_PARAM_PORTDEFINITIONTYPE portdef;
 
-	MAKEME(portdef, OMX_PARAM_PORTDEFINITIONTYPE);
-	portdef->nPortIndex = port;
-	OERR(OMX_GetParameter(h, OMX_IndexParamPortDefinition, portdef));
+    SETUPME(portdef);
+    
+    getPortDef(h, port, &portdef);
 
-	if (enable)
-		OERR(OMX_SendCommand(h, OMX_CommandPortEnable, port, NULL));
+    if (enable)
+        OERRq(OMX_SendCommand(h, OMX_CommandPortEnable, port, NULL));
+    
+    for (i = 0; i < portdef.nBufferCountActual; i++) {
+        OMX_U8 *buf;
 
-	for (i = 0; i < portdef->nBufferCountActual; i++) {
-		OMX_U8 *buf;
+        buf = vcos_malloc_aligned(portdef.nBufferSize, portdef.nBufferAlignment, "buffer");
+        vprintf(V_LOTS, "Allocated a buffer of %d bytes\n", portdef.nBufferSize);
+        
+        OERR(OMX_UseBuffer(h, end, port, NULL, portdef.nBufferSize, buf));
+        end = (OMX_BUFFERHEADERTYPE **) &((*end)->pAppPrivate);
+    }
 
-		buf = vcos_malloc_aligned(portdef->nBufferSize,
-			portdef->nBufferAlignment, "buffer");
-		printf("Allocated a buffer of %d bytes\n",
-			portdef->nBufferSize);
-		OERR(OMX_UseBuffer(h, end, port, NULL, portdef->nBufferSize,
-			buf));
-		end = (OMX_BUFFERHEADERTYPE **) &((*end)->pAppPrivate);
-	}
+    if (enable)
+        waitForCommand(h, OMX_CommandPortEnable, port, NULL);
 
-	free(portdef);
+    return list;
+}
 
-	return list;
+static AVBitStreamFilterContext *getFilter(AVPacket *rp)
+{
+    AVBitStreamFilterContext *bsfc = NULL;
+
+    if (!(rp->data[0] == 0x00 && rp->data[1] == 0x00 &&
+            rp->data[2] == 0x00 && rp->data[3] == 0x01)) {
+        bsfc = av_bitstream_filter_init("h264_mp4toannexb");
+        if (!bsfc) {
+            fprintf(stderr, "Failed to open filter.  This is bad.\n");
+        }
+    }
+
+    return bsfc;
 }
 
 
 
-/* Convert NALs to non-NALs, as per ff_isom_write_avcc() in avc.c */
-static uint8_t *convertnals(uint8_t *sps, int spssize, uint8_t *pps,
-	int ppssize, int *nlen)
+static AVPacket *filter(struct context *pctx, AVPacket *rp)
 {
-	uint8_t *buf;
-	int o;
+    AVPacket *p;
+    AVPacket *fp;
+    int rc;
 
-	if (!sps || !pps) {
-		*nlen = 0;
-		return NULL;
-	}
-	sps += 4;
-	pps += 4;
-	spssize -= 4;
-	ppssize -= 4;
+    fp = calloc(1, sizeof(AVPacket));
 
-	buf = malloc(spssize + ppssize + 16);
-	o = 0;
-	buf[o++] = 1;		/* version */
-	buf[o++] = sps[1];	/* Profile */
-	buf[o++] = sps[2];	/* ...compat */
-	buf[o++] = sps[3];	/* level */
-	buf[o++] = 0xff;	/* 6b res., 2b NAL size -1 */
-	buf[o++] = 0xe1;	/* 3b res., 5b num. SPS (1) */
-	buf[o  ] = htons(spssize);
-	o += 2;
-	memcpy(&buf[o], sps, spssize);
-	o += spssize;
-	buf[o++] = 1;		/* Number of PPS */
-	buf[o  ] = htons(ppssize);
-	o += 2;
-	memcpy(&buf[o], pps, ppssize);
-	o += ppssize;
+    if (pctx->bsfc) {
+        rc = av_bitstream_filter_filter(pctx->bsfc,
+                pctx->ic->streams[pctx->vidindex]->codec,
+                NULL, &(fp->data), &(fp->size),
+                rp->data, rp->size,
+                rp->flags & AV_PKT_FLAG_KEY);
+        if (rc > 0) {
+            av_free_packet(rp);
+            fp->destruct = av_destruct_packet;
+            p = fp;
+        } else {
+            fprintf(stderr, "Failed to filter frame: %d (%x)\n", rc, rc);
+            p = rp;
+        }
+    } else
+        p = rp;
 
-	printf("SPS (%d) + PPS (%d) (=%d); munged into %d\n", spssize, ppssize, spssize+ppssize, o);
-	*nlen = o;
-	return buf;
+    return p;
 }
 
-
-
-static AVBitStreamFilterContext *dofiltertest(AVPacket *rp)
+static void configDeinterlacer(OMX_PARAM_PORTDEFINITIONTYPE *inPortDef, OMX_PARAM_PORTDEFINITIONTYPE *outPortDef)
 {
-	AVBitStreamFilterContext *bsfc;
-	bsfc = NULL;
+    OMX_CONFIG_IMAGEFILTERPARAMSTYPE image_filter;
+    OMX_PARAM_U32TYPE extra_buffers;
+    OMX_HANDLETYPE dei = ctx.dei;
+    
+    SETUPME(extra_buffers);
+    SETUPME(image_filter);
+    vprintf(V_LOTS, "Setting up Deinterlacer\n");
 
-	if (!(rp->data[0] == 0x00 && rp->data[1] == 0x00 &&
-		rp->data[2] == 0x00 && rp->data[3] == 0x01)) {
-		bsfc = av_bitstream_filter_init("h264_mp4toannexb");
-		if (!bsfc) {
-			printf("Failed to open filter.  This is bad.\n");
-		} else {
-			printf("Have a filter at %p\n", bsfc);
-		}
-	} else
-		printf("No need for a filter.\n");
+    setPortDef(dei, PORT_DEI, inPortDef);
+    setPortDef(dei, PORT_DEI + 1, inPortDef);
 
-	return bsfc;
+    /* omxplayer does this: */
+    extra_buffers.nU32 = 3;
+    extra_buffers.nPortIndex = PORT_DEC + 1;
+    OERR(OMX_SetParameter(ctx.dec, OMX_IndexParamBrcmExtraBuffers, &extra_buffers));
+    
+    image_filter.nPortIndex = PORT_DEI + 1;
+    image_filter.nNumParams = 1;
+    image_filter.nParams[0] = 3;
+    image_filter.eImageFilter = OMX_ImageFilterDeInterlaceAdvanced;
+    OERR(OMX_SetConfig(dei, OMX_IndexConfigCommonImageFilterParameters, &image_filter));
+
+    getPortDef(dei, PORT_DEI, outPortDef);
+    vprintf(V_LOTS, "Deinterlacer setup\n");
 }
 
-
-
-static AVPacket *filter(struct context *ctx, AVPacket *rp)
+static void configResizer(OMX_PARAM_PORTDEFINITIONTYPE *inPortDef, OMX_PARAM_PORTDEFINITIONTYPE *outPortDef)
 {
-	AVPacket *p;
-	AVPacket *fp;
-	int rc;
+    int x, y;
+    OMX_PARAM_PORTDEFINITIONTYPE imgportdef;
+    OMX_VIDEO_PORTDEFINITIONTYPE *viddef = &inPortDef->format.video;
+    OMX_IMAGE_PORTDEFINITIONTYPE *imgdef = &imgportdef.format.image;
+    OMX_HANDLETYPE rsz = ctx.rsz;
+    
+    SETUPME(imgportdef);
+    
+    vprintf(V_LOTS, "Setting up Resizer\n");
+    getPortDef(rsz, PORT_RSZ, &imgportdef);
 
-	fp = calloc(1, sizeof(AVPacket));
+    imgdef->nFrameWidth = viddef->nFrameWidth;
+    imgdef->nFrameHeight = viddef->nFrameHeight;
+    imgdef->nStride = viddef->nStride;
+    imgdef->nSliceHeight = viddef->nSliceHeight;
+    imgdef->bFlagErrorConcealment = viddef->bFlagErrorConcealment;
+    imgdef->eCompressionFormat = viddef->eCompressionFormat;
+    imgdef->eColorFormat = viddef->eColorFormat;
+    imgdef->pNativeWindow = viddef->pNativeWindow;
+    
+    setPortDef(rsz, PORT_RSZ, &imgportdef);
 
-	if (ctx->bsfc) {
-		rc = av_bitstream_filter_filter(ctx->bsfc,
-				ctx->ic->streams[ctx->vidindex]->codec,
-				NULL, &(fp->data), &(fp->size),
-				rp->data, rp->size,
-				rp->flags & AV_PKT_FLAG_KEY);
-		if (rc > 0) {
-			av_free_packet(rp);
-			fp->destruct = av_destruct_packet;
-			p = fp;
-		} else {
-			printf("Failed to filter frame: "
-				"%d (%x)\n", rc, rc);
-			p = rp;
-		}
-	} else
-		p = rp;
+    if (sscanf(ctx.resize, "%dx%d", &x, &y) == 2) {
+        imgdef->nFrameWidth = x;
+        imgdef->nFrameHeight = y;
+    } else {
+        imgdef->nFrameWidth *= x;
+        imgdef->nFrameWidth /= 100;
+        imgdef->nFrameHeight *= x;
+        imgdef->nFrameHeight /= 100;
+    }
 
-	return p;
+    /* Ensure width and height are multiples of 16 */
+    imgdef->nFrameWidth += 0x0f;
+    imgdef->nFrameWidth &= ~0x0f;
+    imgdef->nFrameHeight += 0x0f;
+    imgdef->nFrameHeight &= ~0x0f;
+
+    imgdef->nStride = 0;
+    imgdef->nSliceHeight = 0;
+    vprintf(V_INFO, "Frame size: %dx%d, scale factor %d\n", imgdef->nFrameWidth, imgdef->nFrameHeight, x);
+        
+    setPortDef(rsz, PORT_RSZ + 1, &imgportdef);
+
+    getPortDef(rsz, PORT_RSZ + 1, outPortDef);
+    vprintf(V_LOTS, "Resizer setup\n");
 }
 
-
-
-static void configure(struct context *ctx, AVPacket **ifb)
+static void configEncoder(OMX_PARAM_PORTDEFINITIONTYPE *inPortDef)
 {
-	pthread_t			fpst;
-	pthread_attr_t			fpsa;
-	OMX_CONFIG_FRAMERATETYPE	*framerate;
-	OMX_VIDEO_PARAM_PROFILELEVELTYPE *level;
-	OMX_VIDEO_PARAM_BITRATETYPE	*bitrate;
-	OMX_BUFFERHEADERTYPE		*encbufs;
-	OMX_PARAM_PORTDEFINITIONTYPE	*portdef;
-	OMX_VIDEO_PORTDEFINITIONTYPE	*viddef;
-	OMX_PARAM_PORTDEFINITIONTYPE	*imgportdef;
-	OMX_IMAGE_PORTDEFINITIONTYPE	*imgdef;
-	OMX_VIDEO_PARAM_PORTFORMATTYPE	*pfmt;
-	OMX_CONFIG_POINTTYPE		*pixaspect;
-	OMX_HANDLETYPE			dec, enc, rsz, spl, vid, dei;
-	OMX_HANDLETYPE			prev;
-	int				pp;
-	int				x, y;
-	int				i;
-/* omxplayer does this: */
-	OMX_PARAM_U32TYPE		*extra_buffers;
-	OMX_CONFIG_IMAGEFILTERPARAMSTYPE *image_filter;
+    OMX_CONFIG_FRAMERATETYPE framerate;
+    OMX_VIDEO_PARAM_PROFILELEVELTYPE level;
+    OMX_VIDEO_PARAM_BITRATETYPE bitrate;
+    
+    OMX_VIDEO_PARAM_PORTFORMATTYPE pfmt;
+    OMX_HANDLETYPE enc = ctx.enc;
+    OMX_VIDEO_PORTDEFINITIONTYPE *viddef = &inPortDef->format.video;
 
-	MAKEME(portdef, OMX_PARAM_PORTDEFINITIONTYPE);
-	MAKEME(imgportdef, OMX_PARAM_PORTDEFINITIONTYPE);
-	MAKEME(pixaspect, OMX_CONFIG_POINTTYPE);
-	MAKEME(extra_buffers, OMX_PARAM_U32TYPE);
-	MAKEME(image_filter, OMX_CONFIG_IMAGEFILTERPARAMSTYPE);
+    viddef->nBitrate = ctx.bitrate;
+    viddef->eCompressionFormat = OMX_VIDEO_CodingAVC;
+    viddef->nStride = viddef->nSliceHeight = viddef->eColorFormat = 0;
+    setPortDef(enc, PORT_ENC + 1, inPortDef);
+
+    SETUPME(bitrate);
+    bitrate.nPortIndex = PORT_ENC + 1;
+    bitrate.eControlRate = OMX_Video_ControlRateVariable;
+    bitrate.nTargetBitrate = viddef->nBitrate;
+    OERR(OMX_SetParameter(enc, OMX_IndexParamVideoBitrate, &bitrate));
+
+    SETUPME(pfmt);
+    pfmt.nPortIndex = PORT_ENC + 1;
+    pfmt.nIndex = 1;
+    pfmt.eCompressionFormat = OMX_VIDEO_CodingAVC;
+    pfmt.eColorFormat = 0;
+    pfmt.xFramerate = 0;
+    OERR(OMX_SetParameter(enc, OMX_IndexParamVideoPortFormat, &pfmt));
+
+    SETUPME(framerate);
+    framerate.nPortIndex = PORT_ENC + 1;
+    framerate.xEncodeFramerate = viddef->xFramerate;
+    OERR(OMX_SetParameter(enc, OMX_IndexConfigVideoFramerate, &framerate));
+
+    SETUPME(level);
+    level.nPortIndex = PORT_ENC+1;
+    OERR(OMX_GetParameter(enc, OMX_IndexParamVideoProfileLevelCurrent, &level));
+
+    vprintf(V_LOTS, "Current Level:\t%d\tProfile:\t%d\n", level.eLevel, level.eProfile);
+    
+    OERR(OMX_SetParameter(enc, OMX_IndexParamVideoProfileLevelCurrent, &level));
+    
+}
+
+static void configure(struct context *pctx)
+{
+    OMX_PARAM_PORTDEFINITIONTYPE *portdef;
+    OMX_VIDEO_PORTDEFINITIONTYPE *viddef;
+    OMX_PARAM_PORTDEFINITIONTYPE *imgportdef;
+    OMX_IMAGE_PORTDEFINITIONTYPE *imgdef;
+    OMX_HANDLETYPE   dec, enc, rsz, spl, vid, dei;
+    OMX_HANDLETYPE   prev;
+    int    pp;
+    OMX_HANDLETYPE components[5];
+    int handle_count = 0;
+    
+    MAKEME(portdef, OMX_PARAM_PORTDEFINITIONTYPE);
+    MAKEME(imgportdef, OMX_PARAM_PORTDEFINITIONTYPE);
 
 /* These just save a bit of typing.  No other reason. */
-	dec = ctx->dec;
-	enc = ctx->enc;
-	rsz = ctx->rsz;
-	dei = ctx->dei;
-	viddef = &portdef->format.video;
-	imgdef = &imgportdef->format.image;
+    dec = pctx->dec;
+    enc = pctx->enc;
+    rsz = pctx->rsz;
+    dei = pctx->dei;
+    viddef = &portdef->format.video;
+    imgdef = &imgportdef->format.image;
 
-	prev = dec;
-	pp = PORT_DEC+1;
+    prev = dec;
+    pp = PORT_DEC+1;
 
-	printf("Decoder has changed settings.  Setting up encoder.\n");
+    vprintf(V_INFO, "Decoder has changed settings.  Setting up encoder.\n");
 
-	if (ctx->flags & FLAGS_MONITOR) {
-		OERR(OMX_GetHandle(&spl, SPLNAME, &ctx, &genevents));
-		OERR(OMX_GetHandle(&vid, VIDNAME, &ctx, &genevents));
-		for (i = 0; i < 5; i++)
-			OERR(OMX_SendCommand(spl, OMX_CommandPortDisable,
-				PORT_SPL+i, NULL));
-		OERR(OMX_SendCommand(vid, OMX_CommandPortDisable,
-			PORT_VID, NULL));
-	}
+    if (pctx->flags & FLAGS_MONITOR) {
+        int i;
+        OERR(OMX_GetHandle(&spl, SPLNAME, "Splitter", &genevents));
+        OERR(OMX_GetHandle(&vid, VIDNAME, "Renderer", &genevents));
+        for (i = PORT_SPL; i < PORT_SPL + 5; i++)
+            disablePort(spl, i);
+        disablePort(vid, PORT_VID);
+        components[handle_count++] = spl;
+        components[handle_count++] = vid;
+    }
 
-/* Get the decoder port state...: */
-	portdef->nPortIndex = PORT_DEC+1;
-	OERR(OMX_GetParameter(dec, OMX_IndexParamPortDefinition, portdef));
+    /* Get the decoder port state...: */
+    getPortDef(dec, PORT_DEC + 1, portdef);
 
-/* Deinterlacer: */
-	if (ctx->flags & FLAGS_DEINTERLACE) {
-		OERR(OMX_SendCommand(dei, OMX_CommandStateSet, OMX_StateIdle,
-			NULL));
-		portdef->nPortIndex = PORT_DEI;
-		OERR(OMX_SendCommand(dei, OMX_CommandPortDisable,
-				PORT_DEI, NULL));
-		OERR(OMX_SendCommand(dei, OMX_CommandPortDisable,
-				PORT_DEI+1, NULL));
-		OERR(OMX_SetParameter(dei, OMX_IndexParamPortDefinition,
-			portdef));
-		portdef->nPortIndex = PORT_DEI+1;
-		OERR(OMX_SetParameter(dei, OMX_IndexParamPortDefinition,
-			portdef));
+    /* Deinterlacer: */
+    if (pctx->flags & FLAGS_DEINTERLACE) {
 
-/* omxplayer does this: */
-		extra_buffers->nU32 = 3;
-		extra_buffers->nPortIndex = pp;
-		OERR(OMX_SetParameter(prev, OMX_IndexParamBrcmExtraBuffers,
-			extra_buffers));
-		image_filter->nPortIndex = PORT_DEI+1;
-		image_filter->nNumParams = 1;
-		image_filter->nParams[0] = 3;
-		image_filter->eImageFilter = OMX_ImageFilterDeInterlaceAdvanced;
-		OERR(OMX_SetConfig(dei,
-			OMX_IndexConfigCommonImageFilterParameters,
-			image_filter));
+        configDeinterlacer(portdef, imgportdef);
+        
+        viddef->nFrameWidth = imgdef->nFrameWidth;
+        viddef->nFrameHeight = imgdef->nFrameHeight;
+        viddef->nStride = imgdef->nStride;
+        viddef->nSliceHeight = imgdef->nSliceHeight;
+        viddef->bFlagErrorConcealment = imgdef->bFlagErrorConcealment;
+        viddef->eCompressionFormat = imgdef->eCompressionFormat;
+        viddef->eColorFormat = imgdef->eColorFormat;
+        viddef->pNativeWindow = imgdef->pNativeWindow;
 
-		imgportdef->nPortIndex = PORT_DEI;
-		OERR(OMX_GetParameter(dei, OMX_IndexParamPortDefinition,
-			imgportdef));
-		portdef->nPortIndex = PORT_ENC;
-		viddef->nFrameWidth = imgdef->nFrameWidth;
-		viddef->nFrameHeight = imgdef->nFrameHeight;
-		viddef->nStride = imgdef->nStride;
-		viddef->nSliceHeight = imgdef->nSliceHeight;
-		viddef->bFlagErrorConcealment = imgdef->bFlagErrorConcealment;
-		viddef->eCompressionFormat = imgdef->eCompressionFormat;
-		viddef->eColorFormat = imgdef->eColorFormat;
-		viddef->pNativeWindow = imgdef->pNativeWindow;
+        OERR(OMX_SetupTunnel(prev, pp, dei, PORT_DEI));
+        components[handle_count++] = dei;
+        prev = dei;
+        pp = PORT_DEI + 1;
+    }
 
-		dumpport(dei, 190);
-		dumpport(dei, 191);
-//		allocbufs(dei, PORT_DEI+1, 0);
+    if (pctx->resize) {
+        configResizer(portdef, imgportdef);
+       
+        viddef->nFrameWidth = imgdef->nFrameWidth;
+        viddef->nFrameHeight = imgdef->nFrameHeight;
+        viddef->nStride = imgdef->nStride;
+        viddef->nSliceHeight = imgdef->nSliceHeight;
+        viddef->bFlagErrorConcealment = imgdef->bFlagErrorConcealment;
+        viddef->eCompressionFormat = imgdef->eCompressionFormat;
+        viddef->eColorFormat = imgdef->eColorFormat;
+        viddef->pNativeWindow = imgdef->pNativeWindow;
+        components[handle_count++] = rsz;
+    }
 
-		OERR(OMX_SetupTunnel(prev, pp, dei, PORT_DEI));
-		prev = dei;
-		pp = PORT_DEI + 1;
-	}
+    /* ... and feed it to the encoder: */
+    setPortDef(enc, PORT_ENC, portdef);
+    components[handle_count++] = enc;
 
-	if (ctx->resize) {
-		imgportdef->nPortIndex = PORT_RSZ;
-		OERR(OMX_GetParameter(rsz, OMX_IndexParamPortDefinition,
-			imgportdef));
-/*
- * The least they could have done was to make *all* the common elements appear
- * in the same place in the structures, but no...
- */
-		imgdef->nFrameWidth = viddef->nFrameWidth;
-		imgdef->nFrameHeight = viddef->nFrameHeight;
-		imgdef->nStride = viddef->nStride;
-		imgdef->nSliceHeight = viddef->nSliceHeight;
-		imgdef->bFlagErrorConcealment = viddef->bFlagErrorConcealment;
-		imgdef->eCompressionFormat = viddef->eCompressionFormat;
-		imgdef->eColorFormat = viddef->eColorFormat;
-		imgdef->pNativeWindow = viddef->pNativeWindow;
-		OERR(OMX_SetParameter(rsz, OMX_IndexParamPortDefinition,
-			imgportdef));
-		if (sscanf(ctx->resize, "%dx%d", &x, &y) == 2) {
-			x += 0x0f;
-			x &= ~0x0f;
-			y += 0x0f;
-			y &= ~0x0f;
-			imgdef->nFrameWidth = x;
-			imgdef->nFrameHeight = y;
-		} else {
-			imgdef->nFrameWidth *= x;
-			imgdef->nFrameWidth /= 100;
-			imgdef->nFrameWidth += 0x0f;
-			imgdef->nFrameWidth &= ~0x0f;
-			imgdef->nFrameHeight *= x;
-			imgdef->nFrameHeight /= 100;
-			imgdef->nFrameHeight += 0x0f;
-			imgdef->nFrameHeight &= ~0x0f;
-		}
-		imgdef->nStride = 0;
-		imgdef->nSliceHeight = 0;
-		printf("Frame size: %dx%d, scale factor %d\n",
-			imgdef->nFrameWidth, imgdef->nFrameHeight, x);
-		imgportdef->nPortIndex = PORT_RSZ+1;
-		OERR(OMX_SetParameter(rsz, OMX_IndexParamPortDefinition,
-			imgportdef));
-		usleep(40);
-		OERR(OMX_GetParameter(rsz, OMX_IndexParamPortDefinition,
-			imgportdef));
-		portdef->nPortIndex = PORT_ENC;
-		viddef->nFrameWidth = imgdef->nFrameWidth;
-		viddef->nFrameHeight = imgdef->nFrameHeight;
-		viddef->nStride = imgdef->nStride;
-		viddef->nSliceHeight = imgdef->nSliceHeight;
-		viddef->bFlagErrorConcealment = imgdef->bFlagErrorConcealment;
-		viddef->eCompressionFormat = imgdef->eCompressionFormat;
-		viddef->eColorFormat = imgdef->eColorFormat;
-		viddef->pNativeWindow = imgdef->pNativeWindow;
-	}
+    vprintf(V_LOTS, "Setting up tunnels\n");
+    /* Setup the tunnel(s): */
+    if (pctx->flags & FLAGS_MONITOR) {
+        setPortDef(spl, PORT_SPL, portdef);
+        setPortDef(spl, PORT_SPL + 1, portdef);
+        setPortDef(spl, PORT_SPL + 2, portdef);
 
-/* ... and feed it to the encoder: */
-	portdef->nPortIndex = PORT_ENC;
-	OERR(OMX_SetParameter(enc, OMX_IndexParamPortDefinition, portdef));
+        OERR(OMX_SetupTunnel(prev, pp, spl, PORT_SPL));
+        OERR(OMX_SetupTunnel(spl, PORT_SPL + 2, vid, PORT_VID));
+        prev = spl;
+        pp = PORT_SPL + 1;
+    }
 
-/* Setup the tunnel(s): */
-	if (ctx->flags & FLAGS_MONITOR) {
-		OERR(OMX_SendCommand(vid, OMX_CommandStateSet, OMX_StateIdle,
-			NULL));
-		OERR(OMX_SendCommand(spl, OMX_CommandStateSet, OMX_StateIdle,
-			NULL));
-		portdef->nPortIndex = PORT_VID;
-//		OERR(OMX_SetParameter(vid, OMX_IndexParamPortDefinition, portdef));
-dumpport(spl, PORT_SPL);
-		portdef->nPortIndex = PORT_SPL;
-		OERR(OMX_SetParameter(spl, OMX_IndexParamPortDefinition,
-			portdef));
-		portdef->nPortIndex = PORT_SPL+1;
-		OERR(OMX_SetParameter(spl, OMX_IndexParamPortDefinition,
-			portdef));
-		portdef->nPortIndex = PORT_SPL+2;
-		OERR(OMX_SetParameter(spl, OMX_IndexParamPortDefinition,
-			portdef));
-		OERR(OMX_SetupTunnel(prev, pp, spl, PORT_SPL));
-		OERR(OMX_SetupTunnel(spl, PORT_SPL+2, vid, PORT_VID));
-		prev = spl;
-		pp = PORT_SPL+1;
-	}
-	if (ctx->resize) {
-		OERR(OMX_SetupTunnel(prev, pp, rsz, PORT_RSZ));
-		prev = rsz;
-		pp = PORT_RSZ+1;
-	}
-	OERR(OMX_SendCommand(enc, OMX_CommandStateSet, OMX_StateIdle, NULL));
-	dumpport(prev, pp);
-	dumpport(enc, PORT_ENC);
-	OERR(OMX_SetupTunnel(prev, pp, enc, PORT_ENC));
+    if (pctx->resize) {
+        OERR(OMX_SetupTunnel(prev, pp, rsz, PORT_RSZ));
+        prev = rsz;
+        pp = PORT_RSZ + 1;
+    }
+    
+    OERR(OMX_SetupTunnel(prev, pp, enc, PORT_ENC));
+    vprintf(V_LOTS, "Tunnels setup\n");
+    transistionComponents(components, handle_count, OMX_StateIdle);
 
-	if (ctx->bitrate == 0) {
-		viddef->nBitrate *= 3;
-		viddef->nBitrate /= 4;
-	} else {
-		if (ctx->bitrate == 0)
-			viddef->nBitrate = (2*1024*1024);
-		else
-			viddef->nBitrate = ctx->bitrate;
-		ctx->bitrate = viddef->nBitrate;
-	}
+    configEncoder(portdef);
+    
+    pctx->encbufs = allocBuffers(enc, PORT_ENC + 1, 1);
 
-	viddef->eCompressionFormat = OMX_VIDEO_CodingAVC;
-	viddef->nStride = viddef->nSliceHeight = viddef->eColorFormat = 0;
-	portdef->nPortIndex = PORT_ENC+1;
-	OERR(OMX_SetParameter(enc, OMX_IndexParamPortDefinition, portdef));
+    enablePortNW(enc, PORT_ENC);
 
-	MAKEME(bitrate, OMX_VIDEO_PARAM_BITRATETYPE);
-	bitrate->nPortIndex = PORT_ENC+1;
-	bitrate->eControlRate = OMX_Video_ControlRateVariable;
-	bitrate->nTargetBitrate = viddef->nBitrate;
-	OERR(OMX_SetParameter(enc, OMX_IndexParamVideoBitrate, bitrate));
+    enablePort(dec, PORT_DEC + 1);
+    
+    if (pctx->resize) {
+        enablePort(rsz, PORT_RSZ);
+        enablePort(rsz, PORT_RSZ + 1);
+    }
+    
+    if (pctx->flags & FLAGS_MONITOR) {
+        enablePort(vid, PORT_VID);
+        enablePort(spl, PORT_SPL);
+        enablePort(spl, PORT_SPL + 1);
+        enablePort(spl, PORT_SPL + 2);
+    }
 
-	MAKEME(pfmt, OMX_VIDEO_PARAM_PORTFORMATTYPE);
-	pfmt->nPortIndex = PORT_ENC+1;
-	pfmt->nIndex = 0;
-	pfmt->eCompressionFormat = OMX_VIDEO_CodingAVC;
-	pfmt->eColorFormat = OMX_COLOR_FormatYUV420PackedPlanar;
-	pfmt->xFramerate = viddef->xFramerate;
+    if (pctx->flags & FLAGS_DEINTERLACE) {
+        enablePort(dei, PORT_DEI);
+        enablePort(dei, PORT_DEI + 1);
+    }
 
-	pixaspect->nPortIndex = PORT_ENC+1;
-	pixaspect->nX = 64;
-	pixaspect->nY = 45;
-//	OERR(OMX_SetParameter(dec, OMX_IndexParamBrcmPixelAspectRatio, pixaspect));
+    waitForPortEnabled(enc, PORT_ENC);
+    transistionComponents(components, handle_count, OMX_StateExecuting);
 
-//		DUMPPORT(enc, PORT_ENC+1); exit(0);
+    OERR(OMX_FillThisBuffer(enc, pctx->encbufs));
 
-	pfmt->nPortIndex = PORT_ENC+1;
-	pfmt->nIndex = 1;
-	pfmt->eCompressionFormat = OMX_VIDEO_CodingAVC;
-	pfmt->eColorFormat = 0;
-	pfmt->xFramerate = 0; //viddef->xFramerate;
-	OERR(OMX_SetParameter(enc, OMX_IndexParamVideoPortFormat,
-		pfmt));
+    /* Make an output context, possibly: */
+    if (pctx->flags & FLAGS_RAW) {
+        pctx->fd = open(pctx->oname, O_CREAT|O_TRUNC|O_WRONLY, 0777);
+        if (pctx->fd == -1) {
+            fprintf(stderr, "Failed to open the output: %s\n", strerror(errno));
+            exit(1);
+        }
+    } else {
+        pctx->oc = makeOutputContext(pctx->ic, pctx->oname, pctx->vidindex, portdef);
+        if (!pctx->oc) {
+            fprintf(stderr, "Whoops.\n");
+            exit(1);
+        }
+    }
 
-	MAKEME(framerate, OMX_CONFIG_FRAMERATETYPE);
-	framerate->nPortIndex = PORT_ENC+1;
-	framerate->xEncodeFramerate = viddef->xFramerate;
-	OERR(OMX_SetParameter(enc, OMX_IndexConfigVideoFramerate, framerate));
+    atexit(dumpPortState);
 
-#if 0 /* Doesn't seem to apply to video? */
-printf("Interlacing: %d\n", ic->streams[vidindex]->codec->field_order);
-	if (0 || ic->streams[vidindex]->codec->field_order == AV_FIELD_TT) {
-		interlace->nPortIndex = PORT_ENC+1;
-		interlace->eMode = OMX_InterlaceFieldsInterleavedUpperFirst;
-		interlace->bRepeatFirstField = 0;
-		OERR(OMX_SetParameter(enc, OMX_IndexConfigCommonInterlace,
-			interlace));
-	}
-#endif
-
-	MAKEME(level, OMX_VIDEO_PARAM_PROFILELEVELTYPE);
-	level->nPortIndex = PORT_ENC+1;
-	OERR(OMX_GetParameter(enc, OMX_IndexParamVideoProfileLevelCurrent,
-		level));
-	printf("Current level:\t\t%d\nCurrent profile:\t%d\n",
-		level->eLevel, level->eProfile);
-	OERR(OMX_SetParameter(enc, OMX_IndexParamVideoProfileLevelCurrent,
-		level));
-
-	ctx->encbufs = encbufs = allocbufs(enc, PORT_ENC+1, 1);
-	OERR(OMX_SendCommand(dec, OMX_CommandPortEnable, PORT_DEC+1, NULL));
-	if (ctx->resize) {
-		OERR(OMX_SendCommand(rsz, OMX_CommandPortEnable, PORT_RSZ,
-			NULL));
-		OERR(OMX_SendCommand(rsz, OMX_CommandPortEnable, PORT_RSZ+1,
-			NULL));
-	}
-
-	OERR(OMX_SendCommand(enc, OMX_CommandPortEnable, PORT_ENC, NULL));
-
-	if (ctx->flags & FLAGS_MONITOR) {
-		OERR(OMX_SendCommand(vid, OMX_CommandPortEnable, PORT_VID,
-			NULL));
-		OERR(OMX_SendCommand(spl, OMX_CommandPortEnable, PORT_SPL,
-			NULL));
-		OERR(OMX_SendCommand(spl, OMX_CommandPortEnable, PORT_SPL+1,
-			NULL));
-		OERR(OMX_SendCommand(spl, OMX_CommandPortEnable, PORT_SPL+2,
-			NULL));
-// sleep(1); printf("\n\n\n\n\n"); for (i = 0; i < 5; i++) dumpport(spl, PORT_SPL+i); sleep(1);
-printf("Pre-sleep.\n"); fflush(stdout);
-		sleep(1);	/* Should probably wait for an event instead */
-printf("Post-sleep.\n"); fflush(stdout);
-		OERR(OMX_SendCommand(vid, OMX_CommandStateSet,
-			OMX_StateExecuting, NULL));
-		OERR(OMX_SendCommand(spl, OMX_CommandStateSet,
-			OMX_StateExecuting, NULL));
-	}
-
-	if (ctx->flags & FLAGS_DEINTERLACE) {
-		OERR(OMX_SendCommand(dei, OMX_CommandPortEnable, PORT_DEI,
-			NULL));
-		OERR(OMX_SendCommand(dei, OMX_CommandPortEnable, PORT_DEI+1,
-			NULL));
-/* This is another port-changed event I should wait for: */
-		sleep(1);
-		dumpport(dei, 190);
-		dumpport(dei, 191);
-		OERR(OMX_SendCommand(dei, OMX_CommandStateSet,
-			OMX_StateExecuting, NULL));
-	}
-
-	if (ctx->resize)
-		OERR(OMX_SendCommand(rsz, OMX_CommandStateSet,
-			OMX_StateExecuting, NULL));
-	OERR(OMX_SendCommand(enc, OMX_CommandStateSet,
-		OMX_StateExecuting, NULL));
-	sleep(1);
-	OERR(OMX_FillThisBuffer(enc, encbufs));
-
-/* Dump current port states: */
-	dumpport(dec, PORT_DEC);
-	dumpport(dec, PORT_DEC+1);
-	if (ctx->resize) {
-		dumpport(rsz, PORT_RSZ);
-		dumpport(rsz, PORT_RSZ+1);
-	}
-	dumpport(enc, PORT_ENC);
-	dumpport(enc, PORT_ENC+1);
-
-/* Make an output context, possibly: */
-	if ((ctx->flags & FLAGS_RAW) == 0) {
-		ctx->oc = makeoutputcontext(ctx->ic, ctx->oname, ctx->vidindex,
-			portdef, ifb);
-		if (!ctx->oc) {
-			fprintf(stderr, "Whoops.\n");
-			exit(1);
-		}
-	}
-
-	atexit(dumpportstate);
-	pthread_attr_init(&fpsa);
-	pthread_attr_setdetachstate(&fpsa, PTHREAD_CREATE_DETACHED);
-	pthread_create(&fpst, &fpsa, fps, NULL);
 }
 
+static OMX_BUFFERHEADERTYPE* configDecoder(AVStream *videoStream) 
+{
+    OMX_BUFFERHEADERTYPE  *decbufs;
+    OMX_HANDLETYPE dec = ctx.dec;
+    OMX_PARAM_PORTDEFINITIONTYPE portdef;
+    OMX_VIDEO_PORTDEFINITIONTYPE *viddef;
+    
+    SETUPME(portdef);
+    
+    getPortDef(dec, PORT_DEC, &portdef);
+
+    viddef = &portdef.format.video;
+    viddef->nFrameWidth = videoStream->codec->width;
+    viddef->nFrameHeight = videoStream->codec->height;
+    
+    viddef->eCompressionFormat = mapCodec(videoStream->codec->codec_id);
+    vprintf(V_LOTS, "Mapping codec %d to %d\n",
+        videoStream->codec->codec_id, viddef->eCompressionFormat);
+
+    viddef->bFlagErrorConcealment = 0;
+    setPortDef(dec, PORT_DEC, &portdef);
+
+    setState(dec, OMX_StateIdle);
+
+    decbufs = allocBuffers(dec, PORT_DEC, 1);
+
+    ctx.decstate = DECINIT;
+    setState(dec, OMX_StateExecuting);
+    return decbufs;
+}
+
+static void setupOpenMax(void)
+{
+    OMX_HANDLETYPE dec = NULL, enc = NULL, rsz = NULL, dei = NULL;
+    
+    bcm_host_init();
+    OERR(OMX_Init());
+    
+    OERR(OMX_GetHandle(&dec, DECNAME, "Decoder", &decevents));
+    OERR(OMX_GetHandle(&enc, ENCNAME, "Encoder", &encevents));
+    OERR(OMX_GetHandle(&rsz, RSZNAME, "Resizer", &rszevents));
+    OERR(OMX_GetHandle(&dei, DEINAME, "Deinterlacer", &genevents));
+    ctx.dec = dec;
+    ctx.enc = enc;
+    ctx.rsz = rsz;
+    ctx.dei = dei;
+
+    disablePort(dec, PORT_DEC);
+    disablePort(dec, PORT_DEC + 1);
+
+    disablePort(enc, PORT_ENC);
+    disablePort(enc, PORT_ENC+1);
+    
+    if (ctx.resize) {
+        disablePort(rsz, PORT_RSZ);
+        disablePort(rsz, PORT_RSZ + 1);
+    }
+    
+    if (ctx.flags & FLAGS_DEINTERLACE) {
+        disablePort(dei, PORT_DEI);
+        disablePort(dei, PORT_DEI + 1);
+    }
+}
+
+static void setupFpsThread(void)
+{
+    pthread_t fpst;
+    pthread_attr_t fpsa;
+    
+    pthread_attr_init(&fpsa);
+    pthread_attr_setdetachstate(&fpsa, PTHREAD_CREATE_DETACHED);
+    pthread_create(&fpst, &fpsa, fps, NULL);    
+}
 
 
 static void usage(const char *name)
 {
-	fprintf(stderr, "Usage: %s [-b bitrate] [-d] [-m] [-r size] <infile> "
-		"<outfile>\n\n"
-		"Where:\n"
-	"\t-b bitrate\tTarget bitrate in bits/second (default: 2Mb/s)\n"
-	"\t-d\t\tDeinterlace\n"
-	"\t-m\t\tMonitor.  Display the decoder's output\n"
-	"\t-r size\t\tResize output.  'size' is either a percentage, or XXxYY\n"
-	"\t-x\t\tDon't copy subtitles\n"
-	"\n"
-	"Output container is guessed based on filename.  Use '.nal' for raw"
-	" output.\n"
-	"\n", name);
-	exit(1);
+    fprintf(stderr, "Usage: %s [-b bitrate] [-d] [-m] [-r size] <infile> "
+        "<outfile>\n\n"
+        "Where:\n"
+    "\t-v\tIncrease the amount of diagnostic information output.\n"
+    "\t-b bitrate\tTarget bitrate in bits/second (default: 2Mb/s)\n"
+    "\t-d\t\tDeinterlace\n"
+    "\t-m\t\tMonitor.  Display the decoder's output\n"
+    "\t-r size\t\tResize output.  'size' is either a percentage, or XXxYY\n"
+    "\t-x\t\tDon't copy subtitles\n"
+    "\n"
+    "Output container is guessed based on filename.  Use '.nal' for raw"
+    " output.\n"
+    "\n", name);
+    exit(1);
 }
 
-
-
-static void freepacket(AVPacket *p)
+static void freePacket(AVPacket *p)
 {
-	if (p->data)
-		free(p->data);
-	p->data = NULL;
-	p->destruct = av_destruct_packet;
-	av_free_packet(p);
+    if (p->data)
+        free(p->data);
+    p->data = NULL;
+    p->destruct = av_destruct_packet;
+    av_free_packet(p);
 }
 
+static int getNextVideoPacket(AVPacket *pkt)
+{
+    int rc;
+    do
+    {
+        rc = av_read_frame(ctx.ic, pkt);
+        if (rc == 0) {
+            if (pkt->stream_index != ctx.vidindex) {
 
+                if (ctx.decstate == ENCRUNNING) {
+                    writeNonVideoPacket(pkt);
+
+                } else if ((ctx.flags & FLAGS_RAW) == 0) {
+                    /* Save packet for when we open the output file */
+                    struct packet_entry *entry;
+                    entry = malloc(sizeof(struct packet_entry));
+                    entry->packet = *pkt;
+                    TAILQ_INSERT_TAIL(&packetq, entry, link);
+                    /* We've copied out the contents of the packet so re-initialise */
+                    av_init_packet(pkt);
+                } else {
+                    av_free_packet(pkt);
+                }
+            }
+        }
+    }while ((rc == 0) && (pkt->stream_index != ctx.vidindex));
+    return rc;
+}
 
 int main(int argc, char *argv[])
 {
-	AVFormatContext	*ic;
-	AVFormatContext	*oc;
-	char		*iname;
-	char		*oname;
-	int		err;
-	int		vidindex;
-	int		i, j;
-	OMX_ERRORTYPE	oerr;
-	OMX_HANDLETYPE	dec = NULL, enc = NULL, rsz = NULL, dei = NULL;
-	OMX_VIDEO_PARAM_PORTFORMATTYPE	*pfmt;
-	OMX_PORT_PARAM_TYPE		*porttype;
-	OMX_PARAM_PORTDEFINITIONTYPE	*portdef;
-	OMX_BUFFERHEADERTYPE		*decbufs;
-	OMX_VIDEO_PORTDEFINITIONTYPE	*viddef;
-	OMX_VIDEO_PARAM_PROFILELEVELTYPE *level;
-	time_t		start, end;
-	int		offset;
-	AVPacket	*p, *rp;
-	int		ish264;
-	int		filtertest;
-	int		opt;
-	uint8_t		*tmpbuf;
-	off_t		tmpbufoff;
-	AVPacket	**ifb;
-	int		ifbo;
-	uint8_t		*sps, *pps;
-	int		spssize, ppssize;
-	int		fd;
+    AVFormatContext *ic = NULL;
+    AVFormatContext *oc = NULL;
+    char  *iname;
+    char  *oname;
+    int  err;
+    int  vidindex;
+    int  i;
+    OMX_HANDLETYPE dec = NULL, enc = NULL;
+    OMX_BUFFERHEADERTYPE  *decbufs;
+    time_t  start, end;
+    int  offset;
+    AVPacket videoPacket;
+    AVPacket *p, *rp;
+    int  ish264;
+    int  filtertest;
+    int  opt;
+    uint8_t  *tmpbuf;
+    off_t  tmpbufoff;
+    uint8_t *sps = NULL, *pps = NULL;
+    int  spssize = 0, ppssize = 0;
+    int  fd;
+    struct event_info event;
 
-	if (argc < 3)
-		usage(argv[0]);
+    if (argc < 3)
+        usage(argv[0]);
 
-	ctx.bitrate = 2*1024*1024;
+    TAILQ_INIT(&eventq.head);
+    TAILQ_INIT(&packetq);
+    pthread_mutex_init(&ctx.lock, NULL);
+    
+    ctx.bitrate = 2*1024*1024;
 
-	while ((opt = getopt(argc, argv, "b:dmxr:")) != -1) {
-		switch (opt) {
-		case 'b':
-			ctx.bitrate = atoi(optarg);
-			break;
-		case 'd':
-			ctx.flags |= FLAGS_DEINTERLACE;
-			break;
-		case 'm':
-			ctx.flags |= FLAGS_MONITOR;
-			break;
-		case 'r':
-			ctx.resize = optarg;
-			break;
-		case 'x':
-			ctx.no_subtitles = true;
-			break;
-		case '?':
-			usage(argv[0]);
-		}
-	}
+    while ((opt = getopt(argc, argv, "b:dmxr:v")) != -1) {
+        switch (opt) {
+        case 'b':
+            ctx.bitrate = atoi(optarg);
+            break;
+        case 'd':
+            ctx.flags |= FLAGS_DEINTERLACE;
+            break;
+        case 'm':
+            ctx.flags |= FLAGS_MONITOR;
+            break;
+        case 'r':
+            ctx.resize = optarg;
+            break;
+        case 'x':
+            ctx.no_subtitles = true;
+            break;
+        case 'v':
+            ctx.verbosity ++;
+            break;
+        case '?':
+            usage(argv[0]);
+            break;
+        }
+    }
 
-	iname = argv[optind++];
-	oname = argv[optind++];
-	ctx.oname = oname;
-	j = strlen(oname);
-	if (strncmp(&oname[j-4], ".nal", 4) == 0 ||
-		strncmp(&oname[j-4], ".264", 4) == 0) {
-		ctx.flags |= FLAGS_RAW;
-		fd = open(oname, O_CREAT|O_TRUNC|O_WRONLY, 0777);
-		if (fd == -1) {
-			fprintf(stderr,
-				"Failed to open the output: %s\n",
-				strerror(errno));
-			exit(1);
-		}
-	}
+    iname = argv[optind++];
+    oname = argv[optind++];
+    ctx.oname = oname;
+    i = strlen(oname);
+    if (strncmp(&oname[i-4], ".nal", 4) == 0 ||
+        strncmp(&oname[i-4], ".264", 4) == 0) {
+        ctx.flags |= FLAGS_RAW;
+    }
 
-	MAKEME(porttype, OMX_PORT_PARAM_TYPE);
-	MAKEME(portdef, OMX_PARAM_PORTDEFINITIONTYPE);
-	MAKEME(pfmt, OMX_VIDEO_PARAM_PORTFORMATTYPE);
+    av_register_all();
+    
+    /* Input init: */
+    if ((err = avformat_open_input(&ic, iname, NULL, NULL) != 0)) {
+        fprintf(stderr, "Failed to open '%s': %s\n", iname, strerror(err));
+        exit(1);
+    }
+    ctx.ic = ic;
 
-	av_register_all();
+    if (avformat_find_stream_info(ic, NULL) < 0) {
+        fprintf(stderr, "Failed to find streams in '%s'\n", iname);
+        exit(1);
+    }
 
-	ic = NULL;
-	ish264 = 0;
-	pthread_mutex_init(&ctx.lock, NULL);
+    av_dump_format(ic, 0, iname, 0);
 
-	sps = pps = NULL;
-	spssize = ppssize = 0;
+    vidindex = av_find_best_stream(ic, AVMEDIA_TYPE_VIDEO, -1, -1, NULL, 0);
+    if (vidindex < 0) {
+        fprintf(stderr, "Failed to find a video stream in '%s'\n", iname);
+        exit(1);
+    }
+    vprintf(V_LOTS, "Found a video at index %d\n", vidindex);
 
-#if 0
-	{
-		AVOutputFormat *fmt;
-		fmt = av_oformat_next(fmt);
-		while (fmt) {
-			printf("Found '%s'\t\t'%s'\n", fmt->name, fmt->long_name);
-			fmt = av_oformat_next(fmt);
-		}
-		exit(0);
-	}
-#endif
+    vprintf(V_INFO, "Frame size: %dx%d\n", ic->streams[vidindex]->codec->width, 
+        ic->streams[vidindex]->codec->height);
+    
+    ish264 = (ic->streams[vidindex]->codec->codec_id == CODEC_ID_H264);
 
-	/* Input init: */
-
-	if ((err = avformat_open_input(&ic, iname, NULL, NULL) != 0)) {
-		fprintf(stderr, "Failed to open '%s': %s\n", iname,
-			strerror(err));
-		exit(1);
-	}
-	ctx.ic = ic;
-
-	if (avformat_find_stream_info(ic, NULL) < 0) {
-		fprintf(stderr, "Failed to find streams in '%s'\n", iname);
-		exit(1);
-	}
-
-	av_dump_format(ic, 0, iname, 0);
-
-	vidindex = av_find_best_stream(ic, AVMEDIA_TYPE_VIDEO, -1, -1,
-		NULL, 0);
-	if (vidindex < 0) {
-		fprintf(stderr, "Failed to find a video stream in '%s'\n",
-			iname);
-		exit(1);
-	}
-	printf("Found a video at index %d\n", vidindex);
-
-	printf("Frame size: %dx%d\n", ic->streams[vidindex]->codec->width, 
-		ic->streams[vidindex]->codec->height);
-	ish264 = (ic->streams[vidindex]->codec->codec_id == CODEC_ID_H264);
-
-	/* Output init: */
-#if 0
-	ctx.fd = fd = open(oname, O_CREAT | O_LARGEFILE | O_WRONLY | O_TRUNC,
-			0666);
-	printf("File descriptor %d\n", fd);
-#endif
-
-	for (i = 0; i < ic->nb_streams; i++) {
-		printf("Found stream %d, context %p\n",
-			ic->streams[i]->index, ic->streams[i]->codec);
-	}
-
-	bcm_host_init();
-	OERR(OMX_Init());
-	OERR(OMX_GetHandle(&dec, DECNAME, &ctx, &decevents));
-	OERR(OMX_GetHandle(&enc, ENCNAME, &ctx, &encevents));
-	OERR(OMX_GetHandle(&rsz, RSZNAME, &ctx, &rszevents));
-	OERR(OMX_GetHandle(&dei, DEINAME, &ctx, &genevents));
-	ctx.dec = dec;
-	ctx.enc = enc;
-	ctx.rsz = rsz;
-	ctx.dei = dei;
-
-	printf("Obtained handles.  %p decode, %p encode\n",
-		dec, enc);
-
-	OERR(OMX_GetParameter(dec, OMX_IndexParamVideoInit, porttype));
-	printf("Found %d ports, starting at %d (%x) on decoder\n",
-		porttype->nPorts, porttype->nStartPortNumber,
-		porttype->nStartPortNumber);
-
-	OERR(OMX_GetParameter(enc, OMX_IndexParamVideoInit, porttype));
-	printf("Found %d ports, starting at %d (%x) on encoder\n",
-		porttype->nPorts, porttype->nStartPortNumber,
-		porttype->nStartPortNumber);
-
-	OERR(OMX_GetParameter(rsz, OMX_IndexParamImageInit, porttype));
-	printf("Found %d ports, starting at %d(%x) on resizer\n",
-		porttype->nPorts, porttype->nStartPortNumber,
-		porttype->nStartPortNumber);
-
-	OERR(OMX_SendCommand(dec, OMX_CommandPortDisable, PORT_DEC, NULL));
-	OERR(OMX_SendCommand(dec, OMX_CommandPortDisable, PORT_DEC+1, NULL));
-	OERR(OMX_SendCommand(enc, OMX_CommandPortDisable, PORT_ENC, NULL));
-	OERR(OMX_SendCommand(enc, OMX_CommandPortDisable, PORT_ENC+1, NULL));
-	if (ctx.resize) {
-		OERR(OMX_SendCommand(rsz, OMX_CommandPortDisable, PORT_RSZ,
-			NULL));
-		OERR(OMX_SendCommand(rsz, OMX_CommandPortDisable, PORT_RSZ+1,
-			NULL));
-	}
-
-	portdef->nPortIndex = PORT_DEC;
-	OERR(OMX_GetParameter(dec, OMX_IndexParamPortDefinition, portdef));
-	viddef = &portdef->format.video;
-	viddef->nFrameWidth = ic->streams[vidindex]->codec->width;
-	viddef->nFrameHeight = ic->streams[vidindex]->codec->height;
-	printf("Mapping codec %d to %d\n",
-		ic->streams[vidindex]->codec->codec_id,
-		mapcodec(ic->streams[vidindex]->codec->codec_id));
-	viddef->eCompressionFormat = 
-		mapcodec(ic->streams[vidindex]->codec->codec_id);
-	viddef->bFlagErrorConcealment = 0;
-//	viddef->xFramerate = 25<<16;
-	OERR(OMX_SetParameter(dec, OMX_IndexParamPortDefinition, portdef));
-
-#if 0
-/* It appears these have limited effect: */
-	dataunit->nPortIndex = PORT_DEC;
-	dataunit->eUnitType = OMX_DataUnitCodedPicture;
-	dataunit->eEncapsulationType = OMX_DataEncapsulationGenericPayload;
-	OERR(OMX_SetParameter(dec, OMX_IndexParamBrcmDataUnit, dataunit));
-
-	if (ish264) {
-		naltype->nPortIndex = PORT_DEC;
-		naltype->eNaluFormat = OMX_NaluFormatStartCodes;
-		OERR(OMX_SetParameter(dec, OMX_IndexParamNalStreamFormatSelect,
-			naltype));
-	}
-#endif
-
-	MAKEME(level, OMX_VIDEO_PARAM_PROFILELEVELTYPE);
-	level->nPortIndex = PORT_ENC+1;
-/* Dump what the encoder is capable of: */
-	for (oerr = OMX_ErrorNone, i = 0; oerr == OMX_ErrorNone; i++) {
-		pfmt->nIndex = i;
-		oerr = OMX_GetParameter(enc, OMX_IndexParamVideoPortFormat,
-			pfmt);
-		if (oerr == OMX_ErrorNoMore)
-			break;
-		printf("Codecs supported:\n"
-			"\tIndex:\t\t%d\n"
-			"\tCodec:\t\t%d (%x)\n"
-			"\tColour:\t\t%d\n"
-			"\tFramerate:\t%x (%f)\n",
-			pfmt->nIndex,
-			pfmt->eCompressionFormat, pfmt->eCompressionFormat,
-			pfmt->eColorFormat,
-			pfmt->xFramerate,
-			((float)pfmt->xFramerate/(float)65536));
-	}
-
-	for (oerr = OMX_ErrorNone, i = 0; oerr == OMX_ErrorNone; i++) {
-		level->nProfileIndex = i;
-		oerr = OMX_GetParameter(enc,
-			OMX_IndexParamVideoProfileLevelQuerySupported,
-			level);
-		if (oerr == OMX_ErrorNoMore)
-			break;
-		printf("Levels supported:\n"
-			"\tIndex:\t\t%d\n"
-			"\tProfile:\t%d\n"
-			"\tLevel:\t\t%d\n",
-			level->nProfileIndex,
-			level->eProfile,
-			level->eLevel);
-	}
-
-/* Dump current port states: */
-	dumpport(dec, PORT_DEC);
-	dumpport(dec, PORT_DEC+1);
-	if (ctx.resize) {
-		dumpport(rsz, PORT_RSZ);
-		dumpport(rsz, PORT_RSZ+1);
-	}
-	dumpport(enc, PORT_ENC);
-	dumpport(enc, PORT_ENC+1);
-
-	OERR(OMX_SendCommand(dec, OMX_CommandStateSet, OMX_StateIdle, NULL));
-	if (ctx.resize)
-		OERR(OMX_SendCommand(rsz, OMX_CommandStateSet, OMX_StateIdle,
-			NULL));
-
-	decbufs = allocbufs(dec, PORT_DEC, 1);
-
-/* Start the initial loop.  Process until we have a state change on port 131 */
-	ctx.decstate = DECINIT;
-	ctx.encstate = ENCPREINIT;
-	OERR(OMX_SendCommand(dec, OMX_CommandStateSet, OMX_StateExecuting,
-		NULL));
-
-	rp = calloc(1, sizeof(AVPacket));
-	filtertest = ish264;
-	tmpbufoff = 0;
-	tmpbuf = NULL;
-	ifbo = 0;
-	ifb = calloc(1, sizeof(AVPacket *));
-
-	for (offset = i = j = 0; ctx.decstate != DECFAILED; i++, j++) {
-		int rc;
-		int k;
-		int size, nsize;
-		int index;
-		int out_index;
-		OMX_BUFFERHEADERTYPE *spare;
-		AVRational omxtimebase = { 1, 1000000 };
-		OMX_TICKS tick;
-		uint64_t dts = 0;
-
-		if (offset == 0 && ctx.decstate != DECFLUSH) {
-			rc = av_read_frame(ic, rp);
-			if (rc != 0) {
-				if (ic->pb->eof_reached)
-					ctx.decstate = DECFLUSH;
-				break;
-			}
-			index = rp->stream_index;
-			if (index != vidindex) {
-				i--;
-				if (ctx.oc && (ctx.stream_out_idx[index] != -1)) {
-					out_index = ctx.stream_out_idx[index];
-
-					int r;
-					if (rp->pts != AV_NOPTS_VALUE)
-						rp->pts = av_rescale_q(rp->pts,
-							ic->streams[index]->time_base,
-							oc->streams[out_index]->time_base);
-					if (rp->dts != AV_NOPTS_VALUE)
-						rp->dts = av_rescale_q(rp->dts,
-							ic->streams[index]->time_base,
-							oc->streams[out_index]->time_base);
-					rp->stream_index = out_index;
-					r = av_interleaved_write_frame(ctx.oc,
-						rp);
-					if (r < 0)
-						printf("r: %d\n", r);
-				} else if ((ctx.flags & FLAGS_RAW) == 0) {
-					AVPacket *np;
-					ifb = realloc(ifb,
-						sizeof(AVPacket *)*(ifbo+2));
-					np = malloc(sizeof(AVPacket));
-					ifb[ifbo++] = np;
-					ifb[ifbo  ] = NULL;
-					*np = *rp;
-					np->data = malloc(np->size);
-					memcpy(np->data, rp->data, np->size);
-					np->side_data = NULL;
-					np->side_data_elems = 0;
-					np->pos = -1;
-					av_free_packet(rp);
-				} else {
-					av_free_packet(rp);
-				}
-				continue;
-			} else {
-				uint64_t omt;
-
-//				if (rp->pts != AV_NOPTS_VALUE) {
-					omt = av_rescale_q(rp->pts,
-						ic->streams[index]->time_base,
-						omxtimebase);
-					tick.nLowPart = (uint32_t) (omt &
-								0xffffffff);
-					tick.nHighPart = (uint32_t)
-						((omt & 0xffffffff00000000) 
-							>> 32);
-//				} else {
-//					tick.nLowPart = tick.nHighPart = 0;
-//				}
-// printf("Inbound PTS: %lld (%d/%d)\n", rp->pts, ic->streams[index]->time_base.num, ic->streams[index]->time_base.den);
-			}
-
-			size = rp->size;
-			ctx.fps++;
-			ctx.framecount++;
-
-			if (ish264 && filtertest) {
-				filtertest = 0;
-				ctx.bsfc = dofiltertest(rp);
-			}
-			if (ctx.bsfc) {
-				p = filter(&ctx, rp);
-			} else {
-				p = rp;
-			}
-		}
-
-		switch (ctx.decstate) {
-		case DECTUNNELSETUP:
-			start = time(NULL);
-			configure(&ctx, ifb);
-			oc = ctx.oc;
-			ctx.decstate = DECRUNNING;
-			break;
-		case DECFLUSH:
-			size = 0;
-			/* Add the flush code here */
-			break;
-		case DECINIT:
-			if (i < 120) /* Bail; decoder doesn't like it */
-				break;
-			ctx.decstate = DECFAILED;
-			/* Drop through */
-		case DECFAILED:
-			fprintf(stderr, "Failed to set the parameters after "
-					"%d video frames.  Giving up.\n", i);
-			dumpport(dec, PORT_DEC);
-			dumpport(dec, PORT_DEC+1);
-			dumpport(enc, PORT_ENC);
-			dumpport(enc, PORT_ENC+1);
-			exit(1);
-			break;
-		default:
-			break;	/* Shuts the compiler up */
-		}
-
-		for (spare = NULL; !spare; usleep(10)) {
-			pthread_mutex_lock(&ctx.lock);
-			spare = ctx.bufhead;
-			ctx.bufhead = NULL;
-			ctx.flags &= ~FLAGS_DECEMPTIEDBUF;
-			pthread_mutex_unlock(&ctx.lock);
-
-			while (spare) {
-				AVPacket pkt;
-				int r;
-				OMX_TICKS tick = spare->nTimeStamp;
-
-				if (ctx.flags & FLAGS_RAW) {
-					write(fd,
-						&spare->pBuffer[spare->nOffset],
-						spare->nFilledLen);
-					spare->nFilledLen = 0;
-					spare->nOffset = 0;
-					OERRq(OMX_FillThisBuffer(enc, spare));
-					spare = spare->pAppPrivate;
-					continue;
-				}
-
-				if ((spare->nFlags & OMX_BUFFERFLAG_ENDOFNAL)
-					== 0) {
-					if (!tmpbuf)
-						tmpbuf = malloc(1024*1024*1);
-					memcpy(&tmpbuf[tmpbufoff],
-						&spare->pBuffer[spare->nOffset],
-						spare->nFilledLen);
-					tmpbufoff += spare->nFilledLen;
-					spare->nFilledLen = 0;
-					spare->nOffset = 0;
-					OERRq(OMX_FillThisBuffer(enc, spare));
-					spare = spare->pAppPrivate;
-					continue;
-				}
-
-				av_init_packet(&pkt);
-				pkt.stream_index = vidindex;
-				if (tmpbufoff) {
-					memcpy(&tmpbuf[tmpbufoff],
-						&spare->pBuffer[spare->nOffset],
-						spare->nFilledLen);
-					tmpbufoff += spare->nFilledLen;
-					pkt.data = tmpbuf;
-					pkt.size = tmpbufoff;
-					tmpbufoff = 0;
-					tmpbuf = NULL;
-				} else {
-					pkt.data = malloc(spare->nFilledLen);
-					memcpy(pkt.data, spare->pBuffer +
-						spare->nOffset,
-						spare->nFilledLen);
-					pkt.size = spare->nFilledLen;
-				}
-				pkt.destruct = freepacket;
-				if (spare->nFlags & OMX_BUFFERFLAG_SYNCFRAME)
-					pkt.flags |= AV_PKT_FLAG_KEY;
-//				if (spare->nTimeStamp.nLowPart == 0 &&
-//					spare->nTimeStamp.nHighPart == 0) {
-//					pkt.pts = AV_NOPTS_VALUE;
-//				} else {
-					out_index = ctx.stream_out_idx[index];
-
-					pkt.pts = av_rescale_q(((((uint64_t)
-						tick.nHighPart)<<32)
-						| tick.nLowPart), omxtimebase,
-						oc->streams[out_index]->time_base);
-//				}
-				pkt.dts = AV_NOPTS_VALUE; // dts;
-				dts += ctx.frameduration;
-// printf("PTS: %lld %x\n", pkt.pts, spare->nFlags);
+    setupOpenMax();
+    enc = ctx.enc;
+    dec  = ctx.dec;
+    
+    decbufs = configDecoder(ic->streams[vidindex]);
+    vprintf(V_LOTS, "Decoder setup\n");
+    
+    av_init_packet(&videoPacket);
+    rp = &videoPacket;
+    filtertest = ish264;
+    tmpbufoff = 0;
+    tmpbuf = NULL;
 
 
-				if (pkt.data[0] == 0 && pkt.data[1] == 0 &&
-					pkt.data[2] == 0 && pkt.data[3] == 1) {
-					int nt = pkt.data[4] & 0x1f;
-					if (nt == 7) {
-						if (sps)
-							free(sps);
-						sps = malloc(pkt.size);
-						memcpy(sps, pkt.data,
-							pkt.size);
-						spssize = pkt.size;
-						printf("New SPS, length %d\n", spssize);
-					} else if (nt == 8) {
-						if (pps)
-							free(pps);
-						pps = malloc(pkt.size);
-						memcpy(pps, pkt.data,
-							pkt.size);
-						ppssize = pkt.size;
-						printf("New PPS, length %d\n", ppssize);
-					}
-					if (nt == 7 || nt == 8) {
-						AVCodecContext *c;
-						out_index = ctx.stream_out_idx[index];
-						c = oc->streams[out_index]->codec;
-						if (c->extradata) {
-							av_free(c->extradata);
-							c->extradata = NULL;
-							c->extradata_size = 0;
-						}
-						c->extradata =
-							convertnals(sps,
-								spssize,
-								pps, ppssize,
-								&c->extradata_size);
-					}
-				}
-				out_index = ctx.stream_out_idx[index];
-				pkt.stream_index = out_index;
-				r = av_interleaved_write_frame(ctx.oc, &pkt);
-				if (r != 0) {
-					char err[256];
-					av_strerror(r, err, sizeof(err));
-					printf("Failed to write a video frame: %s (%lld, %llx; %d %d) %x.\n", err, pkt.pts, pkt.pts, tick.nLowPart, tick.nHighPart, spare->nFlags);
-				} else {
-//					printf("Wrote a video frame! %lld (%llx)\n", pkt.pts, pkt.pts);
-				}
-				spare->nFilledLen = 0;
-				spare->nOffset = 0;
-				OERRq(OMX_FillThisBuffer(enc, spare));
-				spare = spare->pAppPrivate;
-			}
+    for (offset = i = 0; ctx.decstate != DECFAILED; i++) {
+        int rc;
+        int k;
+        int size, nsize;
+        int out_index;
+        OMX_BUFFERHEADERTYPE *spare;
+        AVRational omxtimebase = { 1, 1000000 };
+        OMX_TICKS tick;
 
-			spare = decbufs;
-			for (k = 0; spare && spare->nFilledLen != 0; k++)
-				spare = spare->pAppPrivate;
-		}
+        if (offset == 0 && ctx.decstate != DECFLUSH) {
+            uint64_t omt;
+            
+            rc = getNextVideoPacket(rp);
+            if (rc != 0) {
+                if (ic->pb->eof_reached)
+                    ctx.decstate = DECFLUSH;
+                break;
+            }
+            
+            omt = av_rescale_q(rp->pts, ic->streams[vidindex]->time_base, omxtimebase);
+            tick.nLowPart = (uint32_t) (omt & 0xffffffff);
+            tick.nHighPart = (uint32_t)((omt & 0xffffffff00000000) >> 32);
 
-		if (size > spare->nAllocLen) {
-			nsize = spare->nAllocLen;
-		} else {
-			nsize = size;
-		}
+            size = rp->size;
+            ctx.framecount++;
 
-		if (ctx.decstate != DECFLUSH) {
-			memcpy(spare->pBuffer, &(p->data[offset]), nsize);
-			spare->nFlags = i == 0 ? OMX_BUFFERFLAG_STARTTIME : 0;
-			spare->nFlags |= size == nsize ?
-				OMX_BUFFERFLAG_ENDOFFRAME : 0;
-		} else {
-			spare->nFlags = OMX_BUFFERFLAG_STARTTIME |
-					OMX_BUFFERFLAG_EOS;
-		}
-		if (p->flags & AV_PKT_FLAG_KEY)
-			spare->nFlags |= OMX_BUFFERFLAG_SYNCFRAME;
-		spare->nTimeStamp = tick;
-		spare->nFilledLen = nsize;
-		spare->nOffset = 0;
-		OERRq(OMX_EmptyThisBuffer(dec, spare));
-		size -= nsize;
-		if (size) {
-			offset += nsize;
-		} else {
-			offset = 0;
-//			printf("PTS: %lld (%llx)\n", p->pts, p->pts);
-			av_free_packet(p);
-		}
-	}
+            if (ish264 && filtertest) {
+                filtertest = 0;
+                ctx.bsfc = getFilter(rp);
+            }
 
-	end = time(NULL);
+            if (ctx.bsfc) {
+                p = filter(&ctx, rp);
+            } else {
+                p = rp;
+            }
+        }
 
-	printf("Processed %d frames in %d seconds; %df/s\n\n\n",
-		ctx.framecount, end-start, (ctx.framecount/(end-start)));
+        if (getEvent(&event, false)) {
+            if (event.component == dec) {
+                if (event.event == OMX_EventPortSettingsChanged) {
+                    ctx.decstate = DECTUNNELSETUP;
+                }   
+            }
+        }
+        vprintf(V_LOTS, "State %d\n", ctx.decstate);
+        switch (ctx.decstate) {
+        case DECTUNNELSETUP:
+            start = time(NULL);
+            configure(&ctx);
+            setupFpsThread();
+            oc = ctx.oc;
+            fd = ctx.fd;
+            ctx.decstate = ENCSPSPPS;
+            break;
+        case DECFLUSH:
+            size = 0;
+            /* Add the flush code here */
+            break;
+        case DECINIT:
+            if (i < 120) /* Bail; decoder doesn't like it */
+                break;
+            ctx.decstate = DECFAILED;
+            /* Drop through */
+        case DECFAILED:
+            fprintf(stderr, "Failed to set the parameters after %d video frames.  Giving up.\n", i);
+            dumpPort(dec, PORT_DEC);
+            dumpPort(dec, PORT_DEC+1);
+            dumpPort(enc, PORT_ENC);
+            dumpPort(enc, PORT_ENC+1);
+            exit(1);
+            break;
+        default:
+            break; /* Shuts the compiler up */
+        }
 
-	if (oc) {
-		av_write_trailer(oc);
+        for (spare = NULL; spare == NULL; usleep(10)) {
+            pthread_mutex_lock(&ctx.lock);
+            spare = ctx.bufhead;
+            ctx.bufhead = NULL;
+            ctx.flags &= ~FLAGS_DECEMPTIEDBUF;
+            pthread_mutex_unlock(&ctx.lock);
 
-		for (i = 0; i < oc->nb_streams; i++)
-			avcodec_close(oc->streams[i]->codec);
+            /* Process buffers from the encoder */
+            while (spare) {
+                bool write_pkt = (pps != NULL && sps != NULL);
+                AVPacket pkt;
+                int r;
+                OMX_TICKS enc_tick = spare->nTimeStamp;
 
-		avio_close(oc->pb);
-	} else {
-		close(fd);
-	}
+                if (ctx.flags & FLAGS_RAW) {
+                    write(fd, &spare->pBuffer[spare->nOffset], spare->nFilledLen);
+                    spare->nFilledLen = 0;
+                    spare->nOffset = 0;
+                    OERRq(OMX_FillThisBuffer(enc, spare));
+                    spare = spare->pAppPrivate;
+                    continue;
+                }
 
-	return 0;
+                if ((spare->nFlags & OMX_BUFFERFLAG_ENDOFNAL) == 0) {
+                    if (!tmpbuf) {
+                        tmpbuf = malloc(1024*1024*1);
+                    }
+
+                    memcpy(&tmpbuf[tmpbufoff], &spare->pBuffer[spare->nOffset], spare->nFilledLen);
+                    tmpbufoff += spare->nFilledLen;
+                    spare->nFilledLen = 0;
+                    spare->nOffset = 0;
+                    OERRq(OMX_FillThisBuffer(enc, spare));
+                    spare = spare->pAppPrivate;
+                    continue;
+                }
+
+                av_init_packet(&pkt);
+                pkt.stream_index = vidindex;
+                if (tmpbufoff) {
+                    memcpy(&tmpbuf[tmpbufoff], &spare->pBuffer[spare->nOffset], spare->nFilledLen);
+                    tmpbufoff += spare->nFilledLen;
+                    pkt.data = tmpbuf;
+                    pkt.size = tmpbufoff;
+                    tmpbufoff = 0;
+                    tmpbuf = NULL;
+                } else {
+                    pkt.data = malloc(spare->nFilledLen);
+                    memcpy(pkt.data, spare->pBuffer + spare->nOffset, spare->nFilledLen);
+                    pkt.size = spare->nFilledLen;
+                }
+
+                pkt.destruct = freePacket;
+                if (spare->nFlags & OMX_BUFFERFLAG_SYNCFRAME){
+                    pkt.flags |= AV_PKT_FLAG_KEY;
+                }
+                out_index = ctx.stream_out_idx[vidindex];
+
+                pkt.pts = av_rescale_q(((((uint64_t)enc_tick.nHighPart)<<32) | enc_tick.nLowPart), 
+                                        omxtimebase, oc->streams[out_index]->time_base);
+                if (pkt.pts != 0) {
+                    pkt.pts -= oc->start_time / 1000;
+                }
+                printf("V PTS = %lld\n", pkt.pts);
+
+                pkt.dts = AV_NOPTS_VALUE; // dts;
+
+                out_index = ctx.stream_out_idx[vidindex];
+                pkt.stream_index = out_index;
+
+                if (pkt.data[0] == 0 && pkt.data[1] == 0 &&
+                    pkt.data[2] == 0 && pkt.data[3] == 1) {
+                    int nt = pkt.data[4] & 0x1f;
+
+                    if (nt == 7) {
+                        if (sps) {
+                            free(sps);
+                        }
+                        sps = malloc(pkt.size);
+
+                        memcpy(sps, pkt.data, pkt.size);
+                        spssize = pkt.size;
+                        vprintf(V_LOTS, "New SPS, length %d\n", spssize);
+                        write_pkt = false;
+                    } else if (nt == 8) {
+                        if (pps) {
+                            free(pps);
+                        }
+                        pps = malloc(pkt.size);
+
+                        memcpy(pps, pkt.data, pkt.size);
+                        ppssize = pkt.size;
+                        vprintf(V_LOTS, "New PPS, length %d\n", ppssize);
+                        write_pkt = false;
+                    }
+
+                    if ((nt == 7) || (nt == 8)) {
+                        AVCodecContext *c;
+
+                        out_index = ctx.stream_out_idx[vidindex];
+                        c = oc->streams[out_index]->codec;
+                        if (c->extradata) {
+                            av_free(c->extradata);
+                            c->extradata = NULL;
+                            c->extradata_size = 0;
+                        }
+
+                        if (pps != NULL && sps != NULL){
+                            /* No need to do any munging of the data as this is done by libav */
+                            c->extradata_size = spssize + ppssize;
+                            c->extradata = malloc(c->extradata_size);
+                            memcpy(c->extradata, sps, spssize);
+                            memcpy(&c->extradata[spssize], pps, ppssize);
+                            openOutputFile();
+                            ctx.decstate = ENCRUNNING;
+                        }
+                    }
+                }
+
+                if (write_pkt){
+                    r = av_interleaved_write_frame(ctx.oc, &pkt);
+                    if (r != 0) {
+                        char err[256];
+                        av_strerror(r, err, sizeof(err));
+                        printf("Failed to write a video frame: %s (%lld, %llx; %d %d) %x.\n", err, pkt.pts, pkt.pts, 
+                                    enc_tick.nLowPart, enc_tick.nHighPart, spare->nFlags);
+                    }
+                }else {
+                    av_free_packet(&pkt);
+                }
+                spare->nFilledLen = 0;
+                spare->nOffset = 0;
+                OERRq(OMX_FillThisBuffer(enc, spare));
+                spare = spare->pAppPrivate;
+            }
+
+            /* Are any decoder buffers empty? if not we'll wait a bit more and then go round again */
+            spare = decbufs;
+            for (k = 0; spare && spare->nFilledLen != 0; k++)
+                spare = spare->pAppPrivate;
+        }
+
+        /* Fill a packet for the decoder */
+        if (size > spare->nAllocLen) {
+            nsize = spare->nAllocLen;
+        } else {
+            nsize = size;
+        }
+        
+        if (ctx.decstate != DECFLUSH) {
+            memcpy(spare->pBuffer, &(p->data[offset]), nsize);
+            spare->nFlags = i == 0 ? OMX_BUFFERFLAG_STARTTIME : 0;
+            spare->nFlags |= size == nsize ? OMX_BUFFERFLAG_ENDOFFRAME : 0;
+        } else {
+            spare->nFlags = OMX_BUFFERFLAG_STARTTIME | OMX_BUFFERFLAG_EOS;
+        }
+
+        if (p->flags & AV_PKT_FLAG_KEY){ 
+            spare->nFlags |= OMX_BUFFERFLAG_SYNCFRAME;
+        }
+
+        spare->nTimeStamp = tick;
+        spare->nFilledLen = nsize;
+        spare->nOffset = 0;
+        OERRq(OMX_EmptyThisBuffer(dec, spare));
+        size -= nsize;
+        if (size) {
+            offset += nsize;
+        } else {
+            offset = 0;
+            av_free_packet(p);
+        }
+    }
+
+    end = time(NULL);
+
+    printf("Processed %d frames in %d seconds; %df/s\n\n\n",
+        ctx.framecount, end-start, (ctx.framecount/(end-start)));
+
+    if (oc) {
+        av_write_trailer(oc);
+
+        for (i = 0; i < oc->nb_streams; i++)
+            avcodec_close(oc->streams[i]->codec);
+
+        avio_close(oc->pb);
+    } else {
+        close(fd);
+    }
+
+    return 0;
 }
+


### PR DESCRIPTION
Hi Dickon,

This is a major update so I will understand if you don't want to pull as is, but take inspiration from it.

I've rewritten the openmax setup and basically broken it down into more understandable chunks, I've also removed the sleeps and replaced them with a message passing system to wait for confirmation on commands.

Added to that I've fixed the problem of the H264 header info not being in the proper place in the file for mp4 and mkv files. I've also rebased the PTS timestamps to ensure that mkv files now show the proper duration.

Finally I've added an option to remove subtitles (I've got a lot of recordings that contain DVB subtitles that don't fit into the common container formats).

Oh and the bit that I now tends to be a hot topic I converted the tabs to spaces, sorry :-)

My raspberrypi has now churned through ~440GB of  MPEG2 transport stream recordings without issue.

Cheers

Adam
