### PR TITLE
Update omxtx.c

### DIFF
--- a/omxtx.c
+++ b/omxtx.c
@@ -1334,6 +1334,7 @@ int main(int argc, char *argv[])
 	MAKEME(pfmt, OMX_VIDEO_PARAM_PORTFORMATTYPE);
 
 	av_register_all();
+	avformat_network_init();
 
 	ic = NULL;
 	ish264 = 0;


### PR DESCRIPTION
fix warn message when transcoding
Using network protocols without global network initialization. Please use avformat_network_init(), this will become mandatory later.